### PR TITLE
feat(ai): Claude Code + opencode activity lane

### DIFF
--- a/app.go
+++ b/app.go
@@ -57,6 +57,7 @@ type App struct {
 	Embeddings  *service.EmbeddingService
 	Draft       *service.DraftService
 	ShellSetup  *service.ShellSetupService
+	AI          *service.AIService
 
 	// Inference engine
 	inference *inference.Service
@@ -121,6 +122,7 @@ func (a *App) startup(ctx context.Context) {
 	a.Timeline = service.NewTimelineService(a.store)
 	a.Screenshots = service.NewScreenshotService(a.store, dataDir)
 	a.Config = service.NewConfigService(a.store, a.platform, nil) // daemon set later
+	a.AI = service.NewAIService(a.store)
 	a.Config.SetInferenceUpdater(func(cfg *service.Config) {
 		if a.inference == nil {
 			return
@@ -2174,4 +2176,15 @@ func buildInferenceConfig(config *service.Config) *inference.Config {
 	}
 
 	return ic
+}
+
+// ListAISessions returns AI coding sessions (Claude Code, opencode) that had
+// activity on the given date. Bound to the frontend via Wails.
+func (a *App) ListAISessions(date string) ([]service.AISessionDisplay, error) {
+	return a.AI.ListAISessions(date)
+}
+
+// GetAISession returns detail for one AI session by its native tool ID.
+func (a *App) GetAISession(id string) (*service.AISessionDetail, error) {
+	return a.AI.GetAISession(id)
 }

--- a/app.go
+++ b/app.go
@@ -705,6 +705,11 @@ func (a *App) UninstallShellPlugin(shell string) error {
 	return a.ShellSetup.Uninstall(shellplugin.ShellKind(shell))
 }
 
+// DismissShellOverflow clears the overflow sentinel file.
+func (a *App) DismissShellOverflow() error {
+	return a.ShellSetup.DismissOverflow()
+}
+
 // SearchAllDataSources searches across all event types (git, shell, files, browser, screenshots).
 func (a *App) SearchAllDataSources(query string, maxResults int) ([]*service.SearchResult, error) {
 	if a.Timeline == nil {

--- a/app.go
+++ b/app.go
@@ -131,8 +131,16 @@ func (a *App) startup(ctx context.Context) {
 		a.inference.UpdateConfig(inferenceConfig)
 	})
 
-	// Initialize daemon with default config
+	// Initialize daemon with saved config (falling back to defaults for any
+	// missing fields). Privacy-sensitive flags like AIStorePromptContent
+	// must be read from stored config at startup so the default-off behavior
+	// survives app restarts without the user re-opting-out every time.
 	daemonConfig := tracker.DefaultDaemonConfig(dataDir)
+	if cfg, err := a.Config.GetConfig(); err == nil && cfg != nil {
+		if cfg.DataSources != nil && cfg.DataSources.AITracking != nil {
+			daemonConfig.AIStorePromptContent = cfg.DataSources.AITracking.StorePromptContent
+		}
+	}
 	a.daemon, err = tracker.NewDaemon(daemonConfig, a.store, a.platform)
 	if err != nil {
 		log.Printf("Failed to initialize daemon: %v", err)
@@ -2187,4 +2195,12 @@ func (a *App) ListAISessions(date string) ([]service.AISessionDisplay, error) {
 // GetAISession returns detail for one AI session by its native tool ID.
 func (a *App) GetAISession(id string) (*service.AISessionDetail, error) {
 	return a.AI.GetAISession(id)
+}
+
+// GetAIPromptsForDay returns one entry per user-initiated AI event with
+// optional prompt-text preview. Preview / content are populated only when
+// AITrackingConfig.StorePromptContent is on at ingest time; otherwise both
+// fields come back empty and the frontend renders timestamp-only rows.
+func (a *App) GetAIPromptsForDay(date string) ([]service.AIPromptDisplay, error) {
+	return a.AI.GetAIPromptsForDay(date)
 }

--- a/app.go
+++ b/app.go
@@ -209,6 +209,7 @@ func (a *App) startup(ctx context.Context) {
 
 	// Initialize shell setup service (plugin install/uninstall/status)
 	a.ShellSetup = service.NewShellSetupService(dataDir)
+	a.Config.SetShellSetup(a.ShellSetup)
 
 	// Initialize issues service (for crash/manual reporting)
 	a.Issues = service.NewIssueService(a.store, Version)

--- a/app.go
+++ b/app.go
@@ -17,6 +17,7 @@ import (
 	"traq/internal/service"
 	"traq/internal/storage"
 	"traq/internal/tracker"
+	"traq/internal/tracker/shellplugin"
 
 	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
@@ -55,6 +56,7 @@ type App struct {
 	Projects    *service.ProjectAssignmentService
 	Embeddings  *service.EmbeddingService
 	Draft       *service.DraftService
+	ShellSetup  *service.ShellSetupService
 
 	// Inference engine
 	inference *inference.Service
@@ -204,6 +206,9 @@ func (a *App) startup(ctx context.Context) {
 
 	// Initialize draft service (for AI draft approval workflow)
 	a.Draft = service.NewDraftService(a.store)
+
+	// Initialize shell setup service (plugin install/uninstall/status)
+	a.ShellSetup = service.NewShellSetupService(dataDir)
 
 	// Initialize issues service (for crash/manual reporting)
 	a.Issues = service.NewIssueService(a.store, Version)
@@ -683,6 +688,21 @@ func (a *App) GetScreenshotsForHour(date string, hour int) ([]*service.Screensho
 		return nil, nil
 	}
 	return a.Timeline.GetScreenshotsForHour(date, hour)
+}
+
+// GetShellSetupStatus returns the install/enable state for a given shell.
+func (a *App) GetShellSetupStatus(shell string) (*service.SetupStatus, error) {
+	return a.ShellSetup.Status(shellplugin.ShellKind(shell))
+}
+
+// InstallShellPlugin installs the Traq plugin for the given shell.
+func (a *App) InstallShellPlugin(shell string) error {
+	return a.ShellSetup.Install(shellplugin.ShellKind(shell))
+}
+
+// UninstallShellPlugin removes the Traq plugin for the given shell.
+func (a *App) UninstallShellPlugin(shell string) error {
+	return a.ShellSetup.Uninstall(shellplugin.ShellKind(shell))
 }
 
 // SearchAllDataSources searches across all event types (git, shell, files, browser, screenshots).

--- a/app.go
+++ b/app.go
@@ -138,7 +138,11 @@ func (a *App) startup(ctx context.Context) {
 	daemonConfig := tracker.DefaultDaemonConfig(dataDir)
 	if cfg, err := a.Config.GetConfig(); err == nil && cfg != nil {
 		if cfg.DataSources != nil && cfg.DataSources.AITracking != nil {
-			daemonConfig.AIStorePromptContent = cfg.DataSources.AITracking.StorePromptContent
+			ai := cfg.DataSources.AITracking
+			daemonConfig.AIStorePromptContent = ai.StorePromptContent
+			daemonConfig.AITrackingEnabled = ai.Enabled
+			daemonConfig.AIClaudeEnabled = ai.ClaudeEnabled
+			daemonConfig.AIOpenCodeEnabled = ai.OpenCodeEnabled
 		}
 	}
 	a.daemon, err = tracker.NewDaemon(daemonConfig, a.store, a.platform)

--- a/docs/plans/2026-04-21-shell-plugin-integration-design.md
+++ b/docs/plans/2026-04-21-shell-plugin-integration-design.md
@@ -1,0 +1,243 @@
+# Shell Plugin Integration — Design
+
+**Date:** 2026-04-21
+**Status:** Design approved, ready for implementation plan
+
+## Problem
+
+Traq captures shell history by polling the user's native history file (`~/.bash_history`, `~/.zsh_history`, etc.). Two bash defaults make this unreliable under tmux and multi-terminal use:
+
+1. Bash only flushes its in-memory history to disk when the session exits. Commands run in a live tmux pane are invisible to Traq until that pane closes.
+2. When a session does exit, bash overwrites `~/.bash_history` by default. In tmux with multiple panes, only the last pane to close preserves its history — the rest are lost.
+
+The result: users running Traq inside tmux (which overlaps strongly with the power-user/developer audience) see sparse, incomplete, or empty shell-history data.
+
+Additionally, the native history format carries minimal metadata. No current working directory, no exit code, no duration, no tmux context — information that would meaningfully improve session correlation and activity analysis.
+
+## Goal
+
+Ship a Traq-managed shell plugin that captures commands in real time across all terminals (including every tmux pane) and enriches them with context the native history files don't carry. Preserve today's file-reading path as a fallback so existing users aren't broken.
+
+## Non-goals
+
+- Capturing command *output* (not commands). Out of scope; substantially more invasive.
+- Capturing environment variables or shell state beyond CWD, exit code, duration, and tmux context.
+- Real-time streaming via socket/daemon. A simple append-only log with polling is sufficient at Traq's capture granularity.
+- Replacing the user's history file or interfering with their normal shell history UX.
+
+## Approach
+
+A Traq-managed shell plugin, sourced from the user's shell rc file via a single `source` line, writes each executed command to a dedicated Traq log file (`~/.local/share/traq/shell/history.log`) as a structured TSV. Traq ingests from this log on its existing polling tick, then truncates it.
+
+When the plugin log is present, Traq reads from it. When absent, Traq falls back to the existing native-history-file parser. This preserves behavior for users who don't install the plugin and gives power users a strict upgrade.
+
+Plugin activity is gated by a marker file (`~/.local/share/traq/shell/enabled`). Toggling Shell History off deletes the marker; the plugin stays installed but becomes a zero-cost early-return until the marker reappears. This avoids churn on the user's rc file when toggling the feature.
+
+Supported shells at v1: bash, zsh, fish, PowerShell (matches current tracker coverage).
+
+## Architecture
+
+### New components
+
+**`internal/tracker/shellplugin/embed/`** — shell plugin files embedded in the Go binary via `//go:embed`:
+- `traq.bash` — hooks `PROMPT_COMMAND`
+- `traq.zsh` — hooks `precmd` / `preexec`
+- `traq.fish` — hooks the `fish_postexec` event
+- `Traq.ps1` — overrides the prompt function
+
+Each plugin:
+1. Returns immediately if `~/.local/share/traq/shell/enabled` is missing.
+2. Captures: exit code, duration, CWD, tmux context (`$TMUX` session/window, or `-`), hostname, shell type, command.
+3. Appends one TSV line to `~/.local/share/traq/shell/history.log` atomically.
+4. Stops appending and writes a sentinel file (`shell/overflowed`) if the log exceeds 10 MB.
+
+**`internal/service/shellsetup.go`** — install/uninstall/status service exposed to the frontend:
+- `GetShellSetupStatus() -> { shell, pluginInstalled, markerPresent, rcPath, sourceLinePresent, overflowed }`
+- `InstallShellPlugin(shell)` — writes plugin file, appends fenced source block to rc file, creates marker
+- `UninstallShellPlugin(shell)` — strips fenced block from rc file, deletes plugin + marker
+
+**`internal/tracker/plugin_log.go`** — parser and ingester for the Traq log:
+- Parses TSV format (version marker first byte, tab-separated fields).
+- Unescapes `\t` / `\n` sequences in the command field.
+- Applies exclude patterns from `ShellTracker`.
+- Inserts into `shell_commands` with new columns populated.
+- Truncates the log file after successful ingest.
+
+### Modified components
+
+**`internal/tracker/shell.go`** — `Poll()` becomes:
+1. Check for `shell/history.log`; if present and non-empty, ingest via `plugin_log.go`.
+2. Otherwise (or if the log is empty), run the existing `parseHistory()` on the native history file.
+3. Exclude-pattern logic stays centralized in `ShellTracker` and is applied to both sources.
+
+Native-history checkpointing continues to advance regardless of which source was read, so a user who toggles Shell History or installs the plugin later doesn't re-ingest their entire native history.
+
+**`internal/storage/migrations.go`** — bump `schemaVersion` from 12 to 13 and add idempotent `ALTER TABLE` calls (matching the existing Traq migration pattern — direct `s.db.Exec` with `IF NOT EXISTS`-equivalent guards, not up/down migrations):
+
+```sql
+ALTER TABLE shell_commands ADD COLUMN cwd TEXT;
+ALTER TABLE shell_commands ADD COLUMN exit_code INTEGER;
+ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT;
+```
+
+**`internal/storage/models.go`** — `ShellCommand` gains `CWD sql.NullString`, `ExitCode sql.NullInt64`, `TmuxContext sql.NullString`.
+
+**`app.go`** — three new Wails bindings: `GetShellSetupStatus`, `InstallShellPlugin`, `UninstallShellPlugin`.
+
+**`frontend/src/components/settings/sections/DataSourcesSettings.tsx`** — new "Shell integration" status strip inside the existing Shell History card.
+
+## Data format
+
+**Log path:** `~/.local/share/traq/shell/history.log` (cross-platform: `DataDir() / shell / history.log`).
+
+**Line format:**
+
+```
+<version>\t<unix_ts>\t<exit_code>\t<duration_ms>\t<cwd>\t<tmux_ctx>\t<hostname>\t<shell>\t<command>\n
+```
+
+- `version` = `1` for the initial format. Lines with unknown versions are skipped, not errors.
+- `tmux_ctx` = `<session>:<window>` when `$TMUX` is set, else `-`.
+- Tabs and newlines in the command field are escaped as `\t` and `\n` so each command occupies exactly one log line.
+- Single `printf >> file` write; lines under 4 KB are atomic on Linux (`PIPE_BUF`). Commands longer than 4 KB are truncated with a trailing `…` marker.
+
+**Rotation:** Traq truncates the file to zero length after each successful ingest batch. Bounded size regardless of ingest cadence.
+
+**Overflow:** plugin stops appending and touches `shell/overflowed` when the log exceeds 10 MB. Traq ingests what's present, clears the sentinel, and surfaces a dismissible banner in the UI noting a gap.
+
+**File permissions:** plugin file and log file are created mode `0600`. On Windows, equivalent ACLs restrict to the current user.
+
+## Storage layout
+
+```
+~/.local/share/traq/
+├── shell/
+│   ├── plugin.bash          (installed when bash plugin is active)
+│   ├── plugin.zsh           (installed when zsh plugin is active)
+│   ├── plugin.fish          (installed when fish plugin is active)
+│   ├── plugin.ps1           (installed when PowerShell plugin is active)
+│   ├── enabled              (marker; present iff Shell History is on)
+│   ├── history.log          (the ingest buffer)
+│   └── overflowed           (sentinel; only present after plugin hit size cap)
+├── shell_checkpoint.json    (existing; continues to track native-history offset)
+├── traq.db                  (existing)
+└── …
+```
+
+Uninstall is `rm -rf ~/.local/share/traq/shell/` plus removing the fenced source block from the user's rc file.
+
+## Setup UX
+
+New status strip inside the Shell History card in `DataSourcesSettings.tsx`, visible whenever Shell History is enabled:
+
+| State | Trigger | Helper text | Actions |
+|---|---|---|---|
+| Not installed | no source line in rc | "Install the Traq plugin for real-time capture across tmux and multiple terminals." | Install plugin |
+| Active | source line + marker + recent log activity | "Active. Capturing commands from all shells." | Uninstall |
+| Installed (disabled) | source line present, marker missing | "Plugin installed but idle. Enable Shell History to resume." | Uninstall |
+| Needs attention | source line present, plugin file missing, or overflow sentinel present | Tailored message | Reinstall, Uninstall, Dismiss banner |
+
+**Install action:**
+1. Detect shell (use configured `shellType`; fall back to `$SHELL`).
+2. Write plugin file to `~/.local/share/traq/shell/plugin.<shell>` at mode `0600`.
+3. Locate rc file: `~/.bashrc` / `~/.zshrc` / `~/.config/fish/config.fish` / PowerShell `$PROFILE`. Create with intermediate directories if missing.
+4. Append fenced block:
+   ```
+   # >>> traq shell integration >>>
+   # Managed by Traq. Do not edit between these fences.
+   [ -f "$HOME/.local/share/traq/shell/plugin.bash" ] && . "$HOME/.local/share/traq/shell/plugin.bash"
+   # <<< traq shell integration <<<
+   ```
+5. Create marker file.
+6. Show toast: "Installed. Open a new terminal or run `source ~/.bashrc` to activate."
+
+**Uninstall action:** confirm dialog, strip fenced block from rc file (atomic: temp file + rename), delete plugin file, delete marker. If fences can't be found, refuse to edit and tell the user to remove the `source` line manually.
+
+**No auto-install on toggle.** Enabling Shell History without installing the plugin leaves Traq in fallback mode and surfaces the Install button as a recommendation, not a requirement.
+
+## Privacy & security
+
+**Exclusion happens on ingest, not in the plugin.** The plugin stays minimal — no regex engine, no config to sync. `ShellTracker`'s existing exclude-pattern logic (built-in `password|passwd|secret|token|key=|api_key|apikey|auth` plus trivial-command filter plus user-defined patterns) is applied uniformly to both plugin-log and native-history sources.
+
+**Tradeoff:** sensitive commands briefly land on disk in `history.log` before rotation. Mitigations:
+- Plugin file and log file created mode `0600` (ACL-equivalent on Windows).
+- Traq polls the log on the existing daemon tick cadence; "briefly" is seconds.
+- Truncation after successful ingest means excluded commands are dropped during parse and never reach SQLite.
+
+A future iteration can push exclude patterns into the plugin itself (plugin-side allow/deny) for users who want stronger pre-disk guarantees. Out of scope for v1.
+
+**Uninstall is a true uninstall.** Fence-based edit is atomic (temp file + rename). If fences are missing, the edit is refused rather than risking dotfile corruption.
+
+## Edge cases
+
+- **Rc file missing:** create with just the fenced block and intermediate directories.
+- **Rc file unreadable:** surface exact error in UI, show the fenced block as copy-pasteable so the user can apply manually.
+- **Fenced block already present (reinstall):** replace between fences, don't duplicate.
+- **Fence present but plugin file missing:** "Needs attention" state; reinstall recreates plugin file only.
+- **Multiple shells per user:** status card shows each detected shell with its own state; install is per-shell.
+- **Log line corruption:** unparseable lines are skipped (logged to Traq's log for debugging); ingest continues.
+- **Log overflow:** sentinel file triggers a dismissible banner noting the gap.
+- **Plugin sourced without marker:** plugin early-returns on first line; zero cost.
+- **Tmux not in use:** `$TMUX` unset, `tmux_ctx` field = `-`.
+- **Shell restart needed after install:** UI explicitly instructs user to open a new terminal or `source` the rc file. No attempt to inject into running shells.
+- **Atomic rc-file writes:** write to `<rc>.traq.tmp` with matching permissions, then `os.Rename`.
+
+## Testing
+
+### Unit — `internal/service/shellsetup_test.go`
+
+- Install into empty HOME → rc file created with fenced block, plugin + marker exist at mode `0600`.
+- Install twice → no duplicate fenced block.
+- Install when fence exists but plugin file missing → plugin file restored, fence untouched.
+- Uninstall → fence region removed, plugin + marker deleted, surrounding rc file content byte-identical.
+- Uninstall with missing fences → refuses edit, returns explicit error.
+- Atomic write: inject fs error mid-write → original rc file intact.
+- State detection: each of the four states returns the correct status struct.
+
+### Unit — `internal/tracker/plugin_log_test.go`
+
+- Parse well-formed TSV line with all fields populated.
+- Parse line with `-` tmux context → `tmux_context` NULL.
+- Parse line with escaped tabs/newlines in command → correctly unescaped.
+- Parse line with unknown version marker → skipped, no error.
+- Truncation: write N lines, ingest, verify file size is 0.
+- Exclude patterns applied against the new format.
+
+### Integration — `internal/tracker/shell_integration_test.go`
+
+- Plugin log present → reads from plugin log, native history file untouched.
+- Plugin log absent → falls back to native history file (existing behavior preserved).
+- Both present → plugin log ingested, native-history checkpoint still advanced (so re-enable later doesn't re-ingest old commands).
+
+### Shell-plugin behavior — `internal/tracker/shellplugin/plugin_test.go`
+
+For each embedded plugin (bash, zsh, fish, PowerShell): spawn the shell in an isolated HOME, source the plugin, run a few commands, assert log file contents match expected format. Gated by build tag and `t.Skip` when shell binary is absent.
+
+### E2E — `frontend/e2e/tests/shell-integration.spec.ts`
+
+- Navigate to Settings → Data Sources → Shell History.
+- Assert "Not installed" pill visible.
+- Click "Install plugin" → toast, pill flips to "Active" (mocked status in test mode).
+- Click "Uninstall" → confirm dialog, pill flips back to "Not installed".
+
+### Manual test plan
+
+- Fresh install on Ubuntu bash + tmux: verify commands across multiple panes captured in real time.
+- Install on macOS zsh.
+- Install on Windows PowerShell.
+- Upgrade path: existing Shell History user installs plugin → no duplicate commands, no gaps around transition.
+- Uninstall path: `diff` pre-install and post-uninstall `~/.bashrc` → byte-identical modulo the fenced region.
+
+## Migration
+
+- **Existing users on file-reading mode:** continue working unchanged. No prompt, no forced install. Status strip shows "Not installed" with a soft recommendation.
+- **New install columns are nullable:** file-parsed commands leave them NULL; no backfill needed.
+- **Schema migration:** bumps `schemaVersion` to 13 and adds three nullable columns to `shell_commands`. Forward-only, matching the existing Traq convention. Re-run safe (the codebase already has precedent for idempotent `ALTER TABLE` repair passes).
+
+## Future extensions (not in v1)
+
+- Plugin-side exclude patterns for pre-disk filtering.
+- Richer tmux integration (pane ID, current command in each pane).
+- Capture shell startup/exit events for session correlation.
+- Socket-based streaming for sub-second latency (if ever needed).
+- Backfill: parse existing native history files for CWD via `$OLDPWD`-like heuristics (probably not worth it).

--- a/docs/plans/2026-04-21-shell-plugin-integration-design.md
+++ b/docs/plans/2026-04-21-shell-plugin-integration-design.md
@@ -72,15 +72,13 @@ Each plugin:
 
 Native-history checkpointing continues to advance regardless of which source was read, so a user who toggles Shell History or installs the plugin later doesn't re-ingest their entire native history.
 
-**`internal/storage/migrations.go`** — bump `schemaVersion` from 12 to 13 and add idempotent `ALTER TABLE` calls (matching the existing Traq migration pattern — direct `s.db.Exec` with `IF NOT EXISTS`-equivalent guards, not up/down migrations):
+**`internal/storage/migrations.go`** — bump `schemaVersion` from 12 to 13 and add an idempotent `ALTER TABLE` call (matching the existing Traq migration pattern — direct `s.db.Exec` with `pragma_table_info` guards, not up/down migrations). The `shell_commands` table already carries `working_directory`, `exit_code`, `duration_seconds`, and `hostname`; those fields simply aren't populated by today's native-history parser. Only one new column is needed:
 
 ```sql
-ALTER TABLE shell_commands ADD COLUMN cwd TEXT;
-ALTER TABLE shell_commands ADD COLUMN exit_code INTEGER;
 ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT;
 ```
 
-**`internal/storage/models.go`** — `ShellCommand` gains `CWD sql.NullString`, `ExitCode sql.NullInt64`, `TmuxContext sql.NullString`.
+**`internal/storage/models.go`** — `ShellCommand` gains `TmuxContext sql.NullString`. The existing `WorkingDirectory`, `ExitCode`, `DurationSeconds`, and `Hostname` fields are reused and start getting populated by the plugin-log path.
 
 **`app.go`** — three new Wails bindings: `GetShellSetupStatus`, `InstallShellPlugin`, `UninstallShellPlugin`.
 
@@ -232,7 +230,7 @@ For each embedded plugin (bash, zsh, fish, PowerShell): spawn the shell in an is
 
 - **Existing users on file-reading mode:** continue working unchanged. No prompt, no forced install. Status strip shows "Not installed" with a soft recommendation.
 - **New install columns are nullable:** file-parsed commands leave them NULL; no backfill needed.
-- **Schema migration:** bumps `schemaVersion` to 13 and adds three nullable columns to `shell_commands`. Forward-only, matching the existing Traq convention. Re-run safe (the codebase already has precedent for idempotent `ALTER TABLE` repair passes).
+- **Schema migration:** bumps `schemaVersion` to 13 and adds one nullable `tmux_context` column to `shell_commands`. Forward-only, matching the existing Traq convention. Re-run safe (the codebase already has precedent for idempotent `ALTER TABLE` repair passes).
 
 ## Future extensions (not in v1)
 

--- a/docs/plans/2026-04-21-shell-plugin-integration-manual-test.md
+++ b/docs/plans/2026-04-21-shell-plugin-integration-manual-test.md
@@ -1,0 +1,14 @@
+# Shell Plugin Integration — Manual Verification Checklist
+
+Run each item before merging `feat/shell-plugin-integration` into `master`.
+
+1. **Bash + tmux on Ubuntu:** install via Settings → Data Sources → Shell History → Install plugin. Open two tmux panes, run different commands in each. Confirm both appear in Traq's Shell History within ~10 seconds and the tmux context column distinguishes the panes.
+2. **Zsh on macOS:** same flow as above, selecting zsh as the shell type.
+3. **Fish:** same flow with fish.
+4. **PowerShell on Windows:** install, run a few commands in a fresh PowerShell session, verify capture.
+5. **Upgrade path:** with Shell History already enabled via the file-reading code path, install the plugin. Run 3 distinct commands. Confirm no duplicates appear in Traq (spot-check by timestamp + command in the Shell History view).
+6. **Uninstall:** `sha256sum ~/.bashrc` before install, install, uninstall, re-hash. Confirm byte-identical. Confirm `~/.local/share/traq/shell/plugin.bash` is gone.
+7. **Toggle capture:** install, disable Shell History in Settings, run 5 commands, re-enable. Confirm those 5 commands are NOT captured (marker-gating works).
+8. **Overflow:** disable Shell History but keep plugin installed, write more than 10 MB of junk to `~/.local/share/traq/shell/history.log` (loop `printf '1\t...\n' >> ...`), re-enable Shell History. Confirm the yellow "Shell log hit size limit" banner appears in Settings. Click Dismiss — banner disappears.
+
+Any failure: file a follow-up issue and do not merge.

--- a/docs/plans/2026-04-21-shell-plugin-integration.md
+++ b/docs/plans/2026-04-21-shell-plugin-integration.md
@@ -1,0 +1,2262 @@
+# Shell Plugin Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture shell commands in real time across every tmux pane and terminal by installing a Traq-managed shell plugin, while preserving the existing native-history fallback path.
+
+**Architecture:** A shell-specific plugin file is embedded in the Go binary via `//go:embed` and installed into `~/.local/share/traq/shell/`. The user's rc file gets a single fenced `source` line. The plugin appends structured TSV lines to `~/.local/share/traq/shell/history.log` when a marker file is present. The daemon's existing poll tick drains and truncates that log.
+
+**Tech stack:** Go 1.21+, Wails v2, SQLite, shell scripting (bash/zsh/fish/PowerShell), React + TypeScript for the settings UI.
+
+**Spec:** `docs/plans/2026-04-21-shell-plugin-integration-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `internal/tracker/shellplugin/embed.go` — `//go:embed` wrapper exposing plugin contents
+- `internal/tracker/shellplugin/embed/traq.bash`
+- `internal/tracker/shellplugin/embed/traq.zsh`
+- `internal/tracker/shellplugin/embed/traq.fish`
+- `internal/tracker/shellplugin/embed/Traq.ps1`
+- `internal/tracker/plugin_log.go` — parser + ingester for the Traq log file
+- `internal/tracker/plugin_log_test.go`
+- `internal/service/shellsetup.go` — install/uninstall/status service
+- `internal/service/shellsetup_test.go`
+- `frontend/src/components/settings/ShellIntegrationStrip.tsx`
+- `frontend/e2e/tests/shell-integration.spec.ts`
+
+**Modified files:**
+- `internal/storage/migrations.go` — `schemaVersion` → 13; add `applyMigration13` and repair pass
+- `internal/storage/models.go` — `ShellCommand` gains `TmuxContext sql.NullString`
+- `internal/storage/shell.go` — `SaveShellCommand`, `scanShellCommands`, all `SELECT` lists include `tmux_context`
+- `internal/tracker/shell.go` — `Poll()` reads plugin log first, then native history; builds `ShellCommand` with the new fields
+- `app.go` — three new Wails bindings
+- `frontend/src/api/client.ts` — shell-setup methods
+- `frontend/src/api/hooks.ts` — `useShellSetupStatus`, `useInstallShellPlugin`, `useUninstallShellPlugin`
+- `frontend/src/components/settings/sections/DataSourcesSettings.tsx` — mounts `<ShellIntegrationStrip />` inside Shell History card
+
+---
+
+## Task 1: Schema migration + model updates
+
+**Files:**
+- Modify: `internal/storage/migrations.go`
+- Modify: `internal/storage/models.go`
+- Modify: `internal/storage/shell.go`
+
+- [ ] **Step 1: Write a failing test for the migration**
+
+Create `internal/storage/migrations_shell_tmux_test.go`:
+
+```go
+package storage
+
+import (
+	"testing"
+)
+
+func TestMigration13_AddsTmuxContextColumn(t *testing.T) {
+	store := newTestStore(t)
+	defer store.Close()
+
+	var count int
+	err := store.db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'tmux_context'`,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("pragma_table_info failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected tmux_context column, got count=%d", count)
+	}
+
+	var version int
+	err = store.db.QueryRow(`SELECT version FROM schema_version`).Scan(&version)
+	if err != nil {
+		t.Fatalf("schema_version lookup failed: %v", err)
+	}
+	if version < 13 {
+		t.Fatalf("expected schema version >= 13, got %d", version)
+	}
+}
+```
+
+(If `newTestStore` doesn't already exist, reuse whatever helper the existing `*_test.go` files in `internal/storage/` use — check `shell_test.go`.)
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `go test ./internal/storage -run TestMigration13_AddsTmuxContextColumn -v`
+Expected: FAIL — column does not exist.
+
+- [ ] **Step 3: Bump schema version + add migration function**
+
+In `internal/storage/migrations.go`:
+
+```go
+const schemaVersion = 13
+```
+
+Add, following the pattern of `applyMigration12` (find it in the same file):
+
+```go
+// applyMigration13 adds tmux_context column to shell_commands for plugin-sourced entries.
+func (s *Store) applyMigration13() error {
+	var count int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'tmux_context'`,
+	).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check tmux_context column: %w", err)
+	}
+	if count == 0 {
+		if _, err := s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT`); err != nil {
+			return fmt.Errorf("add tmux_context column: %w", err)
+		}
+	}
+	return nil
+}
+```
+
+Add the dispatch block in `applyMigrations()` just below the migration 12 block:
+
+```go
+if currentVersion < 13 {
+    if err := s.applyMigration13(); err != nil {
+        return fmt.Errorf("failed to apply migration 13: %w", err)
+    }
+}
+```
+
+Add a repair call in `repairMissingTables()`:
+
+```go
+s.repairShellCommandsTable()
+```
+
+And the repair function itself, following the `repairProjectsTable` pattern:
+
+```go
+func (s *Store) repairShellCommandsTable() {
+	var tableCount int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='shell_commands'`).Scan(&tableCount)
+	if err != nil || tableCount == 0 {
+		return
+	}
+	var colCount int
+	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'tmux_context'`).Scan(&colCount)
+	if err == nil && colCount == 0 {
+		s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT`)
+	}
+}
+```
+
+Also add `tmux_context TEXT` to the `shell_commands` block in the `schema` string constant so fresh installs get the column via `CREATE TABLE`.
+
+- [ ] **Step 4: Extend the `ShellCommand` struct**
+
+In `internal/storage/models.go`, update the struct:
+
+```go
+type ShellCommand struct {
+	ID               int64           `json:"id"`
+	Timestamp        int64           `json:"timestamp"`
+	Command          string          `json:"command"`
+	ShellType        string          `json:"shellType"`
+	WorkingDirectory sql.NullString  `json:"workingDirectory"`
+	ExitCode         sql.NullInt64   `json:"exitCode"`
+	DurationSeconds  sql.NullFloat64 `json:"durationSeconds"`
+	Hostname         sql.NullString  `json:"hostname"`
+	TmuxContext      sql.NullString  `json:"tmuxContext"`
+	SessionID        sql.NullInt64   `json:"sessionId"`
+	CreatedAt        int64           `json:"createdAt"`
+}
+```
+
+- [ ] **Step 5: Update all `shell_commands` SQL in `internal/storage/shell.go`**
+
+`SaveShellCommand`:
+
+```go
+func (s *Store) SaveShellCommand(cmd *ShellCommand) (int64, error) {
+	result, err := s.db.Exec(`
+		INSERT INTO shell_commands (
+			timestamp, command, shell_type, working_directory,
+			exit_code, duration_seconds, hostname, tmux_context, session_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		cmd.Timestamp, cmd.Command, cmd.ShellType, cmd.WorkingDirectory,
+		cmd.ExitCode, cmd.DurationSeconds, cmd.Hostname, cmd.TmuxContext, cmd.SessionID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to insert shell command: %w", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get last insert ID: %w", err)
+	}
+	return id, nil
+}
+```
+
+Every `SELECT` list (`GetShellCommandsBySession`, `GetShellCommandsByTimeRange`, `GetRecentShellCommands`, `GetAllShellCommands`, `SearchShellCommands`) needs `tmux_context` added after `hostname`.
+
+Update `scanShellCommands`:
+
+```go
+func scanShellCommands(rows *sql.Rows) ([]*ShellCommand, error) {
+	var commands []*ShellCommand
+	for rows.Next() {
+		cmd := &ShellCommand{}
+		err := rows.Scan(
+			&cmd.ID, &cmd.Timestamp, &cmd.Command, &cmd.ShellType, &cmd.WorkingDirectory,
+			&cmd.ExitCode, &cmd.DurationSeconds, &cmd.Hostname, &cmd.TmuxContext,
+			&cmd.SessionID, &cmd.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan shell command: %w", err)
+		}
+		commands = append(commands, cmd)
+	}
+	return commands, rows.Err()
+}
+```
+
+- [ ] **Step 6: Run tests, confirm pass**
+
+Run: `go test ./internal/storage -v`
+Expected: all existing tests pass plus the new migration test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/storage/migrations.go internal/storage/models.go internal/storage/shell.go internal/storage/migrations_shell_tmux_test.go
+git commit -m "feat: add tmux_context column for shell plugin integration"
+```
+
+---
+
+## Task 2: Plugin log parser
+
+**Files:**
+- Create: `internal/tracker/plugin_log.go`
+- Create: `internal/tracker/plugin_log_test.go`
+
+The parser reads the Traq log file, converts each TSV line into a `*storage.ShellCommand`, and truncates the log after successful ingest.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/tracker/plugin_log_test.go`:
+
+```go
+package tracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParsePluginLogLine_AllFields(t *testing.T) {
+	line := "1\t1745000000\t0\t123\t/home/jl/repos/traq\tmain:1\thost\tbash\tgit push origin master"
+	cmd, err := parsePluginLogLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.Timestamp != 1745000000 {
+		t.Errorf("Timestamp: got %d, want 1745000000", cmd.Timestamp)
+	}
+	if cmd.Command != "git push origin master" {
+		t.Errorf("Command: got %q", cmd.Command)
+	}
+	if cmd.ShellType != "bash" {
+		t.Errorf("ShellType: got %q", cmd.ShellType)
+	}
+	if !cmd.ExitCode.Valid || cmd.ExitCode.Int64 != 0 {
+		t.Errorf("ExitCode: got %+v", cmd.ExitCode)
+	}
+	if !cmd.DurationSeconds.Valid || cmd.DurationSeconds.Float64 != 0.123 {
+		t.Errorf("DurationSeconds: got %+v", cmd.DurationSeconds)
+	}
+	if !cmd.WorkingDirectory.Valid || cmd.WorkingDirectory.String != "/home/jl/repos/traq" {
+		t.Errorf("WorkingDirectory: got %+v", cmd.WorkingDirectory)
+	}
+	if !cmd.TmuxContext.Valid || cmd.TmuxContext.String != "main:1" {
+		t.Errorf("TmuxContext: got %+v", cmd.TmuxContext)
+	}
+	if !cmd.Hostname.Valid || cmd.Hostname.String != "host" {
+		t.Errorf("Hostname: got %+v", cmd.Hostname)
+	}
+}
+
+func TestParsePluginLogLine_NoTmux(t *testing.T) {
+	line := "1\t1745000000\t0\t50\t/tmp\t-\thost\tzsh\tls"
+	cmd, err := parsePluginLogLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.TmuxContext.Valid {
+		t.Errorf("TmuxContext should be invalid for '-', got %+v", cmd.TmuxContext)
+	}
+}
+
+func TestParsePluginLogLine_EscapedCommand(t *testing.T) {
+	line := "1\t1745000000\t0\t0\t/tmp\t-\thost\tbash\techo line1\\nline2"
+	cmd, err := parsePluginLogLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.Command != "echo line1\nline2" {
+		t.Errorf("Command unescape failed: got %q", cmd.Command)
+	}
+}
+
+func TestParsePluginLogLine_UnknownVersion(t *testing.T) {
+	line := "99\t1745000000\t0\t0\t/\t-\th\tbash\tx"
+	_, err := parsePluginLogLine(line)
+	if err != errUnsupportedVersion {
+		t.Errorf("expected errUnsupportedVersion, got %v", err)
+	}
+}
+
+func TestIngestPluginLog_TruncatesAfterRead(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "history.log")
+	content := "1\t1745000000\t0\t0\t/\t-\th\tbash\tls\n" +
+		"1\t1745000001\t0\t0\t/\t-\th\tbash\tpwd\n"
+	if err := os.WriteFile(logPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmds, err := readAndTruncatePluginLog(logPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cmds) != 2 {
+		t.Fatalf("got %d commands, want 2", len(cmds))
+	}
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("log file should be truncated, size=%d", info.Size())
+	}
+}
+
+func TestIngestPluginLog_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "missing.log")
+	cmds, err := readAndTruncatePluginLog(logPath)
+	if err != nil {
+		t.Fatalf("missing file should not error, got %v", err)
+	}
+	if len(cmds) != 0 {
+		t.Errorf("expected 0 commands, got %d", len(cmds))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `go test ./internal/tracker -run TestParsePluginLogLine -v`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Write the parser**
+
+Create `internal/tracker/plugin_log.go`:
+
+```go
+package tracker
+
+import (
+	"bufio"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"traq/internal/storage"
+)
+
+var errUnsupportedVersion = errors.New("unsupported plugin log version")
+
+const pluginLogVersion = "1"
+
+// parsePluginLogLine parses a single TSV line from the Traq plugin log.
+// Format: <version>\t<ts>\t<exit>\t<duration_ms>\t<cwd>\t<tmux>\t<host>\t<shell>\t<command>
+func parsePluginLogLine(line string) (*storage.ShellCommand, error) {
+	parts := strings.SplitN(line, "\t", 9)
+	if len(parts) != 9 {
+		return nil, fmt.Errorf("expected 9 TSV fields, got %d", len(parts))
+	}
+	if parts[0] != pluginLogVersion {
+		return nil, errUnsupportedVersion
+	}
+
+	ts, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parse timestamp: %w", err)
+	}
+
+	cmd := &storage.ShellCommand{
+		Timestamp: ts,
+		ShellType: parts[7],
+		Command:   unescapeCommand(parts[8]),
+	}
+
+	if exitCode, err := strconv.ParseInt(parts[2], 10, 64); err == nil {
+		cmd.ExitCode = sql.NullInt64{Int64: exitCode, Valid: true}
+	}
+	if durMs, err := strconv.ParseInt(parts[3], 10, 64); err == nil {
+		cmd.DurationSeconds = sql.NullFloat64{Float64: float64(durMs) / 1000.0, Valid: true}
+	}
+	if parts[4] != "" && parts[4] != "-" {
+		cmd.WorkingDirectory = sql.NullString{String: parts[4], Valid: true}
+	}
+	if parts[5] != "" && parts[5] != "-" {
+		cmd.TmuxContext = sql.NullString{String: parts[5], Valid: true}
+	}
+	if parts[6] != "" && parts[6] != "-" {
+		cmd.Hostname = sql.NullString{String: parts[6], Valid: true}
+	}
+	return cmd, nil
+}
+
+func unescapeCommand(s string) string {
+	// Reverse the plugin's escaping: \t -> tab, \n -> newline, \\ -> \.
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case 't':
+				b.WriteByte('\t')
+				i += 2
+				continue
+			case 'n':
+				b.WriteByte('\n')
+				i += 2
+				continue
+			case '\\':
+				b.WriteByte('\\')
+				i += 2
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// readAndTruncatePluginLog reads all commands from the plugin log, then truncates the file.
+// Returns (nil, nil) if the file does not exist.
+func readAndTruncatePluginLog(path string) ([]*storage.ShellCommand, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0600)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open plugin log: %w", err)
+	}
+	defer f.Close()
+
+	var commands []*storage.ShellCommand
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		cmd, err := parsePluginLogLine(line)
+		if err != nil {
+			// Skip malformed or unsupported lines silently; corrupt lines
+			// should never block ingestion of valid ones.
+			continue
+		}
+		commands = append(commands, cmd)
+	}
+	if err := scanner.Err(); err != nil {
+		return commands, fmt.Errorf("scan plugin log: %w", err)
+	}
+
+	if err := f.Truncate(0); err != nil {
+		return commands, fmt.Errorf("truncate plugin log: %w", err)
+	}
+	return commands, nil
+}
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `go test ./internal/tracker -run "TestParsePluginLogLine|TestIngestPluginLog" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tracker/plugin_log.go internal/tracker/plugin_log_test.go
+git commit -m "feat: parser for Traq shell plugin log format"
+```
+
+---
+
+## Task 3: Wire the plugin log into ShellTracker.Poll()
+
+**Files:**
+- Modify: `internal/tracker/shell.go`
+- Create: `internal/tracker/shell_integration_test.go`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Create `internal/tracker/shell_integration_test.go`:
+
+```go
+package tracker
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"traq/internal/storage"
+)
+
+// Assumes mock_platform_test.go already provides a fake platform; if the helper
+// signature differs, adjust these tests to match existing conventions.
+
+func TestShellTracker_PollReadsPluginLogWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	store := storage.NewTestStore(t) // or whatever helper exists
+	defer store.Close()
+
+	pluginDir := filepath.Join(dir, "shell")
+	if err := os.MkdirAll(pluginDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(pluginDir, "history.log")
+	content := "1\t1745000000\t0\t10\t/tmp\tmain:1\thost\tbash\tls -la\n"
+	if err := os.WriteFile(logPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	plat := newMockPlatform("bash", "/nonexistent/history_file")
+	tracker := NewShellTracker(plat, store, dir)
+
+	saved, err := tracker.Poll(0)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(saved))
+	}
+	if saved[0].Command != "ls -la" {
+		t.Errorf("Command: got %q", saved[0].Command)
+	}
+	if !saved[0].TmuxContext.Valid || saved[0].TmuxContext.String != "main:1" {
+		t.Errorf("TmuxContext: got %+v", saved[0].TmuxContext)
+	}
+	// Log should have been truncated
+	info, _ := os.Stat(logPath)
+	if info.Size() != 0 {
+		t.Errorf("log not truncated")
+	}
+}
+
+func TestShellTracker_PollFallsBackToNativeHistory(t *testing.T) {
+	dir := t.TempDir()
+	store := storage.NewTestStore(t)
+	defer store.Close()
+
+	histFile := filepath.Join(dir, ".bash_history")
+	content := "#1745000000\nls\n"
+	if err := os.WriteFile(histFile, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	plat := newMockPlatform("bash", histFile)
+	tracker := NewShellTracker(plat, store, dir)
+
+	saved, err := tracker.Poll(0)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(saved) != 1 || saved[0].Command != "ls" {
+		t.Fatalf("unexpected saved: %+v", saved)
+	}
+	if saved[0].TmuxContext.Valid {
+		t.Errorf("native history should not populate tmux_context")
+	}
+}
+```
+
+If `storage.NewTestStore(t)` doesn't exist, check what helper `internal/storage/shell_test.go` uses and mirror that signature, creating a helper if needed. Same for `newMockPlatform` — see `internal/tracker/mock_platform_test.go`.
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `go test ./internal/tracker -run TestShellTracker_Poll -v`
+Expected: FAIL — current `Poll` doesn't know about the plugin log.
+
+- [ ] **Step 3: Update `ShellTracker.Poll()` and add a helper for plugin-log ingestion**
+
+In `internal/tracker/shell.go`, add near the top:
+
+```go
+// pluginLogPath returns the path to the Traq shell plugin log.
+func (t *ShellTracker) pluginLogPath() string {
+	return filepath.Join(filepath.Dir(t.checkpointFile), "shell", "history.log")
+}
+```
+
+Replace `Poll`:
+
+```go
+func (t *ShellTracker) Poll(sessionID int64) ([]*storage.ShellCommand, error) {
+	// 1. Try the Traq plugin log first (richer format, real-time)
+	pluginCmds, err := readAndTruncatePluginLog(t.pluginLogPath())
+	if err != nil {
+		// Log-level failures should not block native fallback; surface only
+		// catastrophic cases (e.g., unreadable file returned what we got).
+		return nil, fmt.Errorf("plugin log: %w", err)
+	}
+
+	// 2. Also read from the native history file (fallback + commands from shells
+	//    without the plugin installed). Existing behavior.
+	nativeCmds, newOffset, err := t.pollNativeHistory()
+	if err != nil {
+		// Non-fatal: continue with plugin commands only
+		nativeCmds = nil
+	}
+
+	// Merge and persist
+	all := append(pluginCmds, nativeCmds...)
+
+	var saved []*storage.ShellCommand
+	for _, cmd := range all {
+		if t.shouldExclude(cmd.Command) {
+			continue
+		}
+		exists, err := t.store.CommandExists(cmd.Timestamp, cmd.Command)
+		if err != nil || exists {
+			continue
+		}
+		cmd.SessionID = sql.NullInt64{Int64: sessionID, Valid: sessionID > 0}
+		id, err := t.store.SaveShellCommand(cmd)
+		if err != nil {
+			continue
+		}
+		cmd.ID = id
+		saved = append(saved, cmd)
+	}
+
+	// Advance native-history checkpoint only if we actually read that source.
+	if newOffset >= 0 {
+		checkpoint, err := t.loadCheckpoint()
+		if err != nil {
+			checkpoint = &ShellCheckpoint{Offsets: make(map[string]int64)}
+		}
+		checkpoint.Offsets[t.currentHistoryPath()] = newOffset
+		t.saveCheckpoint(checkpoint)
+	}
+	return saved, nil
+}
+
+// pollNativeHistory wraps the previous file-reading body of Poll. It returns
+// (nil, -1, nil) if no native history path is configured.
+func (t *ShellTracker) pollNativeHistory() ([]*storage.ShellCommand, int64, error) {
+	histPath := t.currentHistoryPath()
+	if histPath == "" {
+		return nil, -1, nil
+	}
+	shellType := t.GetShellType()
+
+	checkpoint, err := t.loadCheckpoint()
+	if err != nil {
+		checkpoint = &ShellCheckpoint{Offsets: make(map[string]int64)}
+	}
+	offset := checkpoint.Offsets[histPath]
+
+	commands, newOffset, err := t.parseHistory(histPath, shellType, offset)
+	if err != nil {
+		return nil, -1, err
+	}
+	return commands, newOffset, nil
+}
+
+func (t *ShellTracker) currentHistoryPath() string {
+	if t.historyPathOverride != "" {
+		return t.historyPathOverride
+	}
+	return t.platform.GetShellHistoryPath()
+}
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `go test ./internal/tracker -v`
+Expected: all tests pass (the two new integration tests plus the existing shell tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tracker/shell.go internal/tracker/shell_integration_test.go
+git commit -m "feat: shell tracker reads plugin log before native history"
+```
+
+---
+
+## Task 4: Bash plugin + embed machinery
+
+**Files:**
+- Create: `internal/tracker/shellplugin/embed.go`
+- Create: `internal/tracker/shellplugin/embed/traq.bash`
+
+- [ ] **Step 1: Write the bash plugin**
+
+Create `internal/tracker/shellplugin/embed/traq.bash`:
+
+```bash
+# Traq shell integration for bash. Managed by Traq.
+# Do not edit in place — reinstall via the Traq UI to update.
+
+[[ -n "${__TRAQ_LOADED:-}" ]] && return 0
+__TRAQ_LOADED=1
+
+__traq_dir="${XDG_DATA_HOME:-$HOME/.local/share}/traq/shell"
+__traq_marker="$__traq_dir/enabled"
+__traq_log="$__traq_dir/history.log"
+__traq_overflow="$__traq_dir/overflowed"
+__traq_max_bytes=10485760  # 10 MiB
+
+# Capture command start time via PS0 (fires before each command runs).
+# EPOCHREALTIME is bash 5+; fall back to date for older bash.
+if [[ -n "${EPOCHREALTIME:-}" ]]; then
+    PS0='${__traq_start:=$EPOCHREALTIME}'
+else
+    PS0='${__traq_start:=$(date +%s)}'
+fi
+
+__traq_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\n'/\\n}"
+    if [[ ${#s} -gt 4000 ]]; then
+        s="${s:0:4000}…"
+    fi
+    printf '%s' "$s"
+}
+
+__traq_hook() {
+    local exit_code=$?
+    [[ -f "$__traq_marker" ]] || { unset __traq_start; return; }
+
+    # Overflow check
+    if [[ -f "$__traq_log" ]]; then
+        local size
+        size=$(wc -c < "$__traq_log" 2>/dev/null | tr -d ' ')
+        if [[ -n "$size" && "$size" -gt "$__traq_max_bytes" ]]; then
+            : > "$__traq_overflow"
+            unset __traq_start
+            return
+        fi
+    fi
+
+    # Last command via HISTCMD-based lookup
+    local cmd
+    cmd=$(HISTTIMEFORMAT= builtin history 1 2>/dev/null | sed 's/^ *[0-9]* *//')
+    [[ -z "$cmd" ]] && { unset __traq_start; return; }
+
+    local ts
+    ts=$(date +%s)
+
+    local duration_ms=0
+    if [[ -n "${__traq_start:-}" ]]; then
+        local end now
+        if [[ -n "${EPOCHREALTIME:-}" ]]; then
+            end="$EPOCHREALTIME"
+            duration_ms=$(awk -v s="$__traq_start" -v e="$end" 'BEGIN{printf "%.0f", (e - s) * 1000}')
+        else
+            now=$(date +%s)
+            duration_ms=$(( (now - __traq_start) * 1000 ))
+        fi
+    fi
+
+    local tmux_ctx="-"
+    if [[ -n "${TMUX:-}" ]]; then
+        local session window
+        session=$(tmux display-message -p '#S' 2>/dev/null)
+        window=$(tmux display-message -p '#I' 2>/dev/null)
+        [[ -n "$session" && -n "$window" ]] && tmux_ctx="${session}:${window}"
+    fi
+
+    local hostname
+    hostname=$(hostname -s 2>/dev/null || echo "-")
+
+    mkdir -p "$__traq_dir" 2>/dev/null
+    printf '1\t%s\t%s\t%s\t%s\t%s\t%s\tbash\t%s\n' \
+        "$ts" "$exit_code" "$duration_ms" "$PWD" "$tmux_ctx" "$hostname" \
+        "$(__traq_escape "$cmd")" \
+        >> "$__traq_log"
+
+    unset __traq_start
+}
+
+# Prepend to PROMPT_COMMAND so we run first (and don't clobber existing hooks).
+case "${PROMPT_COMMAND:-}" in
+    *"__traq_hook"*) ;;
+    "") PROMPT_COMMAND="__traq_hook" ;;
+    *) PROMPT_COMMAND="__traq_hook; $PROMPT_COMMAND" ;;
+esac
+```
+
+- [ ] **Step 2: Write the embed wrapper**
+
+Create `internal/tracker/shellplugin/embed.go`:
+
+```go
+// Package shellplugin provides embedded shell plugin scripts.
+package shellplugin
+
+import (
+	"embed"
+	"errors"
+)
+
+//go:embed embed/*
+var files embed.FS
+
+// ShellKind enumerates supported plugin shells.
+type ShellKind string
+
+const (
+	Bash       ShellKind = "bash"
+	Zsh        ShellKind = "zsh"
+	Fish       ShellKind = "fish"
+	PowerShell ShellKind = "powershell"
+)
+
+var errUnknownShell = errors.New("unknown shell kind")
+
+// Filename returns the on-disk filename used when installing the plugin.
+func Filename(kind ShellKind) string {
+	switch kind {
+	case Bash:
+		return "plugin.bash"
+	case Zsh:
+		return "plugin.zsh"
+	case Fish:
+		return "plugin.fish"
+	case PowerShell:
+		return "plugin.ps1"
+	}
+	return ""
+}
+
+// Script returns the plugin contents for the given shell.
+func Script(kind ShellKind) ([]byte, error) {
+	var p string
+	switch kind {
+	case Bash:
+		p = "embed/traq.bash"
+	case Zsh:
+		p = "embed/traq.zsh"
+	case Fish:
+		p = "embed/traq.fish"
+	case PowerShell:
+		p = "embed/Traq.ps1"
+	default:
+		return nil, errUnknownShell
+	}
+	return files.ReadFile(p)
+}
+```
+
+Placeholders for zsh/fish/ps1 files are needed for the `//go:embed embed/*` directive to succeed. Create empty-but-valid placeholders:
+- `internal/tracker/shellplugin/embed/traq.zsh` — single line: `# traq zsh plugin — placeholder`
+- `internal/tracker/shellplugin/embed/traq.fish` — single line: `# traq fish plugin — placeholder`
+- `internal/tracker/shellplugin/embed/Traq.ps1` — single line: `# traq PowerShell plugin — placeholder`
+
+These get filled in by Tasks 10–12.
+
+- [ ] **Step 3: Verify the package builds**
+
+Run: `go build ./internal/tracker/shellplugin/`
+Expected: no errors.
+
+- [ ] **Step 4: Behavior test for the bash plugin**
+
+Create `internal/tracker/shellplugin/plugin_bash_test.go`:
+
+```go
+//go:build !windows
+
+package shellplugin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBashPlugin_WritesLogLine(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not installed")
+	}
+
+	home := t.TempDir()
+	shellDir := filepath.Join(home, ".local", "share", "traq", "shell")
+	if err := os.MkdirAll(shellDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	// Marker present → plugin should log
+	if err := os.WriteFile(filepath.Join(shellDir, "enabled"), []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginPath := filepath.Join(home, "plugin.bash")
+	script, err := Script(Bash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, script, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run bash interactively-ish: source the plugin, run one command, exit.
+	cmd := exec.Command("bash", "--noprofile", "--norc", "-c",
+		`set -o history; HISTFILE=/dev/null; source "$1"; echo hello; `+
+			`# PROMPT_COMMAND only fires at prompt; invoke hook manually:
+			__traq_hook`,
+		"--", pluginPath)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash failed: %v\n%s", err, out)
+	}
+
+	logBytes, err := os.ReadFile(filepath.Join(shellDir, "history.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "\tbash\t") {
+		t.Errorf("log missing bash shell marker: %s", logBytes)
+	}
+	if !strings.Contains(string(logBytes), "echo hello") {
+		t.Errorf("log missing command: %s", logBytes)
+	}
+}
+```
+
+Run: `go test ./internal/tracker/shellplugin -v`
+Expected: PASS on a system with bash.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tracker/shellplugin/
+git commit -m "feat: embed bash shell plugin for real-time command capture"
+```
+
+---
+
+## Task 5: ShellSetup service — core paths, status, install/uninstall for bash
+
+**Files:**
+- Create: `internal/service/shellsetup.go`
+- Create: `internal/service/shellsetup_test.go`
+
+- [ ] **Step 1: Write failing tests for path detection and fenced-block editing**
+
+Create `internal/service/shellsetup_test.go`:
+
+```go
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"traq/internal/tracker/shellplugin"
+)
+
+func newShellSetupTest(t *testing.T) (*ShellSetupService, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	dataDir := filepath.Join(home, ".local", "share", "traq")
+	svc := NewShellSetupService(dataDir)
+	return svc, home
+}
+
+func TestInstall_CreatesPluginAndFencesRcFile(t *testing.T) {
+	svc, home := newShellSetupTest(t)
+
+	if err := svc.Install(shellplugin.Bash); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	pluginPath := filepath.Join(home, ".local", "share", "traq", "shell", "plugin.bash")
+	if _, err := os.Stat(pluginPath); err != nil {
+		t.Errorf("plugin file missing: %v", err)
+	}
+
+	rc, err := os.ReadFile(filepath.Join(home, ".bashrc"))
+	if err != nil {
+		t.Fatalf("read .bashrc: %v", err)
+	}
+	s := string(rc)
+	if !strings.Contains(s, traqFenceStart) || !strings.Contains(s, traqFenceEnd) {
+		t.Errorf(".bashrc missing fence: %q", s)
+	}
+	if !strings.Contains(s, "plugin.bash") {
+		t.Errorf(".bashrc missing plugin ref: %q", s)
+	}
+}
+
+func TestInstall_Idempotent(t *testing.T) {
+	svc, home := newShellSetupTest(t)
+	if err := svc.Install(shellplugin.Bash); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if err := svc.Install(shellplugin.Bash); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	rc, _ := os.ReadFile(filepath.Join(home, ".bashrc"))
+	count := strings.Count(string(rc), traqFenceStart)
+	if count != 1 {
+		t.Errorf("fence start appears %d times, want 1: %s", count, rc)
+	}
+}
+
+func TestUninstall_RestoresRcFile(t *testing.T) {
+	svc, home := newShellSetupTest(t)
+	rcPath := filepath.Join(home, ".bashrc")
+	original := "# user content above\nexport PATH=$PATH:/foo\n"
+	if err := os.WriteFile(rcPath, []byte(original), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.Install(shellplugin.Bash); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := svc.Uninstall(shellplugin.Bash); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	got, _ := os.ReadFile(rcPath)
+	if string(got) != original {
+		t.Errorf("rc file not restored\nwant: %q\ngot:  %q", original, got)
+	}
+	pluginPath := filepath.Join(home, ".local", "share", "traq", "shell", "plugin.bash")
+	if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
+		t.Errorf("plugin file not deleted")
+	}
+}
+
+func TestStatus_Transitions(t *testing.T) {
+	svc, _ := newShellSetupTest(t)
+
+	st, err := svc.Status(shellplugin.Bash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != StateNotInstalled {
+		t.Errorf("expected NotInstalled, got %s", st.State)
+	}
+
+	if err := svc.Install(shellplugin.Bash); err != nil {
+		t.Fatal(err)
+	}
+	svc.EnableCapture()
+	st, _ = svc.Status(shellplugin.Bash)
+	if st.State != StateActive {
+		t.Errorf("expected Active, got %s", st.State)
+	}
+
+	svc.DisableCapture()
+	st, _ = svc.Status(shellplugin.Bash)
+	if st.State != StateInstalledDisabled {
+		t.Errorf("expected InstalledDisabled, got %s", st.State)
+	}
+}
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+Run: `go test ./internal/service -run TestInstall -v`
+Expected: FAIL — no types yet.
+
+- [ ] **Step 3: Implement the service**
+
+Create `internal/service/shellsetup.go`:
+
+```go
+package service
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"traq/internal/tracker/shellplugin"
+)
+
+const (
+	traqFenceStart = "# >>> traq shell integration >>>"
+	traqFenceEnd   = "# <<< traq shell integration <<<"
+	markerFilename = "enabled"
+)
+
+type SetupState string
+
+const (
+	StateNotInstalled      SetupState = "not_installed"
+	StateActive            SetupState = "active"
+	StateInstalledDisabled SetupState = "installed_disabled"
+	StateNeedsAttention    SetupState = "needs_attention"
+)
+
+type SetupStatus struct {
+	Shell      shellplugin.ShellKind `json:"shell"`
+	State      SetupState            `json:"state"`
+	RcPath     string                `json:"rcPath"`
+	PluginPath string                `json:"pluginPath"`
+	Overflowed bool                  `json:"overflowed"`
+	Message    string                `json:"message"`
+}
+
+type ShellSetupService struct {
+	dataDir string // e.g. ~/.local/share/traq
+}
+
+func NewShellSetupService(dataDir string) *ShellSetupService {
+	return &ShellSetupService{dataDir: dataDir}
+}
+
+func (s *ShellSetupService) shellDir() string { return filepath.Join(s.dataDir, "shell") }
+func (s *ShellSetupService) markerPath() string {
+	return filepath.Join(s.shellDir(), markerFilename)
+}
+func (s *ShellSetupService) overflowPath() string {
+	return filepath.Join(s.shellDir(), "overflowed")
+}
+func (s *ShellSetupService) pluginPath(kind shellplugin.ShellKind) string {
+	return filepath.Join(s.shellDir(), shellplugin.Filename(kind))
+}
+
+// rcPathFor returns the absolute path to the user's rc file for the given shell.
+func (s *ShellSetupService) rcPathFor(kind shellplugin.ShellKind) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	switch kind {
+	case shellplugin.Bash:
+		return filepath.Join(home, ".bashrc"), nil
+	case shellplugin.Zsh:
+		return filepath.Join(home, ".zshrc"), nil
+	case shellplugin.Fish:
+		return filepath.Join(home, ".config", "fish", "config.fish"), nil
+	case shellplugin.PowerShell:
+		// Caller typically resolves $PROFILE at install time; for tests we
+		// fall back to a predictable path.
+		return filepath.Join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1"), nil
+	}
+	return "", errors.New("unsupported shell")
+}
+
+// sourceLine is the contents placed between the fence markers for each shell.
+func sourceLine(kind shellplugin.ShellKind, pluginPath string) string {
+	switch kind {
+	case shellplugin.Bash, shellplugin.Zsh:
+		return fmt.Sprintf(`[ -f %q ] && . %q`, pluginPath, pluginPath)
+	case shellplugin.Fish:
+		return fmt.Sprintf(`test -f %q; and source %q`, pluginPath, pluginPath)
+	case shellplugin.PowerShell:
+		return fmt.Sprintf(`if (Test-Path %q) { . %q }`, pluginPath, pluginPath)
+	}
+	return ""
+}
+
+func (s *ShellSetupService) Install(kind shellplugin.ShellKind) error {
+	script, err := shellplugin.Script(kind)
+	if err != nil {
+		return fmt.Errorf("load plugin script: %w", err)
+	}
+	if err := os.MkdirAll(s.shellDir(), 0700); err != nil {
+		return fmt.Errorf("create shell dir: %w", err)
+	}
+	pluginPath := s.pluginPath(kind)
+	if err := os.WriteFile(pluginPath, script, 0600); err != nil {
+		return fmt.Errorf("write plugin: %w", err)
+	}
+
+	rcPath, err := s.rcPathFor(kind)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(rcPath), 0755); err != nil {
+		return fmt.Errorf("create rc dir: %w", err)
+	}
+
+	block := strings.Join([]string{
+		traqFenceStart,
+		"# Managed by Traq. Do not edit between these fences.",
+		sourceLine(kind, pluginPath),
+		traqFenceEnd,
+	}, "\n")
+
+	if err := upsertFencedBlock(rcPath, block); err != nil {
+		return fmt.Errorf("update rc file: %w", err)
+	}
+	return nil
+}
+
+func (s *ShellSetupService) Uninstall(kind shellplugin.ShellKind) error {
+	rcPath, err := s.rcPathFor(kind)
+	if err != nil {
+		return err
+	}
+	if err := removeFencedBlock(rcPath); err != nil {
+		return fmt.Errorf("update rc file: %w", err)
+	}
+	if err := os.Remove(s.pluginPath(kind)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove plugin: %w", err)
+	}
+	return nil
+}
+
+func (s *ShellSetupService) EnableCapture() error {
+	if err := os.MkdirAll(s.shellDir(), 0700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(s.markerPath(), os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func (s *ShellSetupService) DisableCapture() error {
+	if err := os.Remove(s.markerPath()); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *ShellSetupService) Status(kind shellplugin.ShellKind) (*SetupStatus, error) {
+	rcPath, err := s.rcPathFor(kind)
+	if err != nil {
+		return nil, err
+	}
+	pluginPath := s.pluginPath(kind)
+
+	rcHasFence := false
+	if data, err := os.ReadFile(rcPath); err == nil {
+		rcHasFence = bytes.Contains(data, []byte(traqFenceStart))
+	}
+	pluginExists := fileExists(pluginPath)
+	markerExists := fileExists(s.markerPath())
+	overflow := fileExists(s.overflowPath())
+
+	status := &SetupStatus{
+		Shell: kind, RcPath: rcPath, PluginPath: pluginPath, Overflowed: overflow,
+	}
+	switch {
+	case rcHasFence && pluginExists && markerExists:
+		status.State = StateActive
+		status.Message = "Capturing commands from all shells."
+	case rcHasFence && pluginExists && !markerExists:
+		status.State = StateInstalledDisabled
+		status.Message = "Plugin installed but idle. Enable Shell History to resume."
+	case rcHasFence && !pluginExists:
+		status.State = StateNeedsAttention
+		status.Message = "Plugin file missing. Reinstall."
+	case !rcHasFence:
+		status.State = StateNotInstalled
+		status.Message = "Install the Traq plugin for real-time capture across tmux and multiple terminals."
+	}
+	if overflow && status.State == StateActive {
+		status.State = StateNeedsAttention
+		status.Message = "Shell log hit size limit while Traq was idle. Some commands may be missing."
+	}
+	return status, nil
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// upsertFencedBlock atomically replaces or appends the fenced block in rcPath.
+func upsertFencedBlock(rcPath, block string) error {
+	existing, err := os.ReadFile(rcPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	var out bytes.Buffer
+	if bytes.Contains(existing, []byte(traqFenceStart)) {
+		scanner := bufio.NewScanner(bytes.NewReader(existing))
+		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+		inside := false
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case !inside && strings.TrimSpace(line) == traqFenceStart:
+				inside = true
+				out.WriteString(block)
+				out.WriteByte('\n')
+			case inside && strings.TrimSpace(line) == traqFenceEnd:
+				inside = false
+			case !inside:
+				out.WriteString(line)
+				out.WriteByte('\n')
+			}
+		}
+	} else {
+		out.Write(existing)
+		if len(existing) > 0 && !bytes.HasSuffix(existing, []byte("\n")) {
+			out.WriteByte('\n')
+		}
+		out.WriteString(block)
+		out.WriteByte('\n')
+	}
+
+	return atomicWriteFile(rcPath, out.Bytes(), 0600)
+}
+
+func removeFencedBlock(rcPath string) error {
+	data, err := os.ReadFile(rcPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !bytes.Contains(data, []byte(traqFenceStart)) {
+		// Nothing to do; refuse silently. Caller can still delete the plugin file.
+		return nil
+	}
+	var out bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	inside := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case !inside && strings.TrimSpace(line) == traqFenceStart:
+			inside = true
+		case inside && strings.TrimSpace(line) == traqFenceEnd:
+			inside = false
+		case !inside:
+			out.WriteString(line)
+			out.WriteByte('\n')
+		}
+	}
+	return atomicWriteFile(rcPath, out.Bytes(), 0600)
+}
+
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".traq.*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+```
+
+- [ ] **Step 4: Tests pass**
+
+Run: `go test ./internal/service -run "TestInstall|TestUninstall|TestStatus" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/shellsetup.go internal/service/shellsetup_test.go
+git commit -m "feat: shell setup service for bash with fenced-block rc editing"
+```
+
+---
+
+## Task 6: Hook into daemon: enable/disable marker tied to Shell History config
+
+**Files:**
+- Modify: `internal/service/config.go` (or wherever the Shell History enabled toggle currently reacts)
+- Modify: `internal/tracker/daemon.go` if it's what propagates the change
+
+- [ ] **Step 1: Locate the existing Shell History toggle handler**
+
+Run: `grep -rn "shell.*enabled\|DataSources.*shell\|shell.*Enabled" internal/ | grep -v _test`
+
+Find where config changes cause the tracker to be re-initialized. Usually this is a setter or watcher on the config service.
+
+- [ ] **Step 2: Add marker management**
+
+In whatever code responds to the Shell History enabled toggle, add a call to `ShellSetupService.EnableCapture()` or `DisableCapture()` accordingly. For example, if the config service holds a `*ShellSetupService`:
+
+```go
+if cfg.DataSources.Shell.Enabled {
+    _ = c.shellSetup.EnableCapture()
+} else {
+    _ = c.shellSetup.DisableCapture()
+}
+```
+
+Wire `ShellSetupService` into `ConfigService` at construction time. Look at how `daemon` and `store` are injected today and follow the same pattern.
+
+- [ ] **Step 3: Test: toggling config flips the marker**
+
+Add to `internal/service/shellsetup_test.go`:
+
+```go
+func TestMarkerTiesToConfigToggle(t *testing.T) {
+	svc, home := newShellSetupTest(t)
+	if err := svc.EnableCapture(); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(home, ".local", "share", "traq", "shell", "enabled")
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("marker missing after EnableCapture: %v", err)
+	}
+	if err := svc.DisableCapture(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Errorf("marker still present after DisableCapture")
+	}
+}
+```
+
+- [ ] **Step 4: Run all service tests**
+
+Run: `go test ./internal/service -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/
+git commit -m "feat: Shell History toggle drives plugin capture marker"
+```
+
+---
+
+## Task 7: Wails bindings in app.go
+
+**Files:**
+- Modify: `app.go`
+
+- [ ] **Step 1: Wire the service into `App`**
+
+Find where other services (e.g. `ConfigService`, timeline service) are constructed in `app.go` or `main.go`. Add a field on `App`:
+
+```go
+ShellSetup *service.ShellSetupService
+```
+
+Initialize it where other services are initialized:
+
+```go
+a.ShellSetup = service.NewShellSetupService(a.platform.DataDir())
+```
+
+- [ ] **Step 2: Add the three bindings**
+
+Append to `app.go`:
+
+```go
+// GetShellSetupStatus returns the install/enable state for a given shell.
+func (a *App) GetShellSetupStatus(shell string) (*service.SetupStatus, error) {
+	return a.ShellSetup.Status(shellplugin.ShellKind(shell))
+}
+
+// InstallShellPlugin installs the Traq plugin for the given shell.
+func (a *App) InstallShellPlugin(shell string) error {
+	return a.ShellSetup.Install(shellplugin.ShellKind(shell))
+}
+
+// UninstallShellPlugin removes the Traq plugin for the given shell.
+func (a *App) UninstallShellPlugin(shell string) error {
+	return a.ShellSetup.Uninstall(shellplugin.ShellKind(shell))
+}
+```
+
+Add `"traq/internal/tracker/shellplugin"` to the imports.
+
+- [ ] **Step 3: Regenerate frontend bindings**
+
+Run: `wails generate bindings -tags webkit2_41`
+
+If that command isn't available in this environment, start `wails dev -tags webkit2_41`, let it regenerate, then stop it.
+
+Verify `frontend/wailsjs/go/main/App.d.ts` now declares `GetShellSetupStatus`, `InstallShellPlugin`, `UninstallShellPlugin`.
+
+- [ ] **Step 4: Build the backend**
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app.go frontend/wailsjs/
+git commit -m "feat: Wails bindings for shell plugin install/uninstall/status"
+```
+
+---
+
+## Task 8: Frontend API client + React Query hooks
+
+**Files:**
+- Modify: `frontend/src/api/client.ts`
+- Modify: `frontend/src/api/hooks.ts`
+
+- [ ] **Step 1: Extend the API client**
+
+In `frontend/src/api/client.ts`, add to the `api` object (match existing style):
+
+```ts
+import {
+  GetShellSetupStatus,
+  InstallShellPlugin,
+  UninstallShellPlugin,
+} from '@wailsjs/go/main/App';
+
+// ... inside api = { ... }
+shellSetup: {
+  status: (shell: string) => GetShellSetupStatus(shell),
+  install: (shell: string) => InstallShellPlugin(shell),
+  uninstall: (shell: string) => UninstallShellPlugin(shell),
+},
+```
+
+- [ ] **Step 2: Add React Query hooks**
+
+In `frontend/src/api/hooks.ts`:
+
+```ts
+export function useShellSetupStatus(shell: string) {
+  return useQuery({
+    queryKey: ['shellSetup', shell],
+    queryFn: () => api.shellSetup.status(shell),
+    refetchInterval: 5000, // polling so UI reflects marker/plugin state changes
+  });
+}
+
+export function useInstallShellPlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (shell: string) => api.shellSetup.install(shell),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['shellSetup'] }),
+  });
+}
+
+export function useUninstallShellPlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (shell: string) => api.shellSetup.uninstall(shell),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['shellSetup'] }),
+  });
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/
+git commit -m "feat: frontend API client for shell plugin setup"
+```
+
+---
+
+## Task 9: ShellIntegrationStrip component + settings integration
+
+**Files:**
+- Create: `frontend/src/components/settings/ShellIntegrationStrip.tsx`
+- Modify: `frontend/src/components/settings/sections/DataSourcesSettings.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `frontend/src/components/settings/ShellIntegrationStrip.tsx`:
+
+```tsx
+import { useShellSetupStatus, useInstallShellPlugin, useUninstallShellPlugin } from '@/api/hooks';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  shell: string;
+}
+
+const stateLabels: Record<string, { pill: string; className: string }> = {
+  not_installed:      { pill: 'Not installed',       className: 'bg-muted text-muted-foreground' },
+  active:             { pill: 'Active',              className: 'bg-green-500/20 text-green-700 dark:text-green-400' },
+  installed_disabled: { pill: 'Installed (disabled)', className: 'bg-yellow-500/20 text-yellow-700 dark:text-yellow-400' },
+  needs_attention:    { pill: 'Needs attention',     className: 'bg-red-500/20 text-red-700 dark:text-red-400' },
+};
+
+export function ShellIntegrationStrip({ shell }: Props) {
+  const { data: status, isLoading } = useShellSetupStatus(shell);
+  const install = useInstallShellPlugin();
+  const uninstall = useUninstallShellPlugin();
+
+  if (isLoading || !status) return null;
+
+  const label = stateLabels[status.state] ?? stateLabels.not_installed;
+
+  return (
+    <div className="rounded-md border bg-muted/30 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">Shell integration</span>
+          <span className={`rounded-full px-2 py-0.5 text-xs ${label.className}`}>
+            {label.pill}
+          </span>
+        </div>
+        <div className="flex gap-2">
+          {status.state === 'not_installed' && (
+            <Button size="sm" onClick={() => install.mutate(shell)} disabled={install.isPending}>
+              Install plugin
+            </Button>
+          )}
+          {status.state === 'needs_attention' && (
+            <Button size="sm" onClick={() => install.mutate(shell)} disabled={install.isPending}>
+              Reinstall
+            </Button>
+          )}
+          {(status.state === 'active' ||
+            status.state === 'installed_disabled' ||
+            status.state === 'needs_attention') && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                if (window.confirm('Remove Traq shell integration?')) {
+                  uninstall.mutate(shell);
+                }
+              }}
+              disabled={uninstall.isPending}
+            >
+              Uninstall
+            </Button>
+          )}
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground">{status.message}</p>
+      {status.state === 'active' && (
+        <p className="text-xs text-muted-foreground">
+          Open a new terminal or run <code className="rounded bg-muted px-1">source {status.rcPath}</code>{' '}
+          to activate in existing shells.
+        </p>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Mount inside the Shell History card**
+
+In `frontend/src/components/settings/sections/DataSourcesSettings.tsx`, inside the Shell History `CollapsibleCard`, before the existing `<SettingsRow label="Shell Type" ...>`:
+
+```tsx
+<ShellIntegrationStrip
+  shell={config.dataSources.shell.shellType === 'auto' || !config.dataSources.shell.shellType
+    ? 'bash' // default; status hook will still work, but bash is the v1 focus
+    : config.dataSources.shell.shellType}
+/>
+```
+
+And import:
+
+```tsx
+import { ShellIntegrationStrip } from '../ShellIntegrationStrip';
+```
+
+- [ ] **Step 3: Manual UI check**
+
+Run: `wails dev -tags webkit2_41`
+
+Open Settings → Data Sources → Shell History (expand). Verify the "Shell integration" strip appears with "Not installed" state. Click "Install plugin" — pill flips to "Active" after polling tick.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/settings/
+git commit -m "feat: Shell integration status strip in Settings"
+```
+
+---
+
+## Task 10: Zsh plugin
+
+**Files:**
+- Modify: `internal/tracker/shellplugin/embed/traq.zsh`
+- Create: `internal/tracker/shellplugin/plugin_zsh_test.go`
+
+- [ ] **Step 1: Write the zsh plugin**
+
+Replace `internal/tracker/shellplugin/embed/traq.zsh`:
+
+```bash
+# Traq shell integration for zsh.
+
+[[ -n "${__TRAQ_LOADED:-}" ]] && return 0
+__TRAQ_LOADED=1
+
+__traq_dir="${XDG_DATA_HOME:-$HOME/.local/share}/traq/shell"
+__traq_marker="$__traq_dir/enabled"
+__traq_log="$__traq_dir/history.log"
+__traq_overflow="$__traq_dir/overflowed"
+__traq_max_bytes=10485760
+
+__traq_start=0
+
+__traq_preexec() {
+    __traq_cmd="$1"
+    __traq_start=$EPOCHREALTIME
+}
+
+__traq_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\n'/\\n}"
+    if (( ${#s} > 4000 )); then
+        s="${s:0:4000}…"
+    fi
+    print -rn -- "$s"
+}
+
+__traq_precmd() {
+    local exit_code=$?
+    [[ -z "${__traq_cmd:-}" ]] && return
+    [[ -f "$__traq_marker" ]] || { __traq_cmd=""; return; }
+
+    if [[ -f "$__traq_log" ]]; then
+        local size
+        size=$(wc -c < "$__traq_log" 2>/dev/null | tr -d ' ')
+        if [[ -n "$size" && "$size" -gt "$__traq_max_bytes" ]]; then
+            : > "$__traq_overflow"
+            __traq_cmd=""
+            return
+        fi
+    fi
+
+    local end duration_ms=0
+    end=$EPOCHREALTIME
+    duration_ms=$(awk -v s="$__traq_start" -v e="$end" 'BEGIN{printf "%.0f", (e - s) * 1000}')
+
+    local tmux_ctx="-"
+    if [[ -n "${TMUX:-}" ]]; then
+        local session window
+        session=$(tmux display-message -p '#S' 2>/dev/null)
+        window=$(tmux display-message -p '#I' 2>/dev/null)
+        [[ -n "$session" && -n "$window" ]] && tmux_ctx="${session}:${window}"
+    fi
+
+    local hostname
+    hostname=$(hostname -s 2>/dev/null || echo "-")
+
+    mkdir -p "$__traq_dir" 2>/dev/null
+    printf '1\t%s\t%s\t%s\t%s\t%s\t%s\tzsh\t%s\n' \
+        "$(date +%s)" "$exit_code" "$duration_ms" "$PWD" "$tmux_ctx" "$hostname" \
+        "$(__traq_escape "$__traq_cmd")" \
+        >> "$__traq_log"
+    __traq_cmd=""
+}
+
+autoload -Uz add-zsh-hook
+zmodload zsh/datetime 2>/dev/null
+add-zsh-hook preexec __traq_preexec
+add-zsh-hook precmd  __traq_precmd
+```
+
+- [ ] **Step 2: Add behavior test**
+
+Create `internal/tracker/shellplugin/plugin_zsh_test.go`:
+
+```go
+//go:build !windows
+
+package shellplugin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestZshPlugin_WritesLogLine(t *testing.T) {
+	if _, err := exec.LookPath("zsh"); err != nil {
+		t.Skip("zsh not installed")
+	}
+
+	home := t.TempDir()
+	shellDir := filepath.Join(home, ".local", "share", "traq", "shell")
+	if err := os.MkdirAll(shellDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shellDir, "enabled"), []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginPath := filepath.Join(home, "plugin.zsh")
+	script, err := Script(Zsh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, script, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force precmd/preexec to fire by running a command and invoking them manually.
+	cmd := exec.Command("zsh", "--no-rcs", "-c",
+		`source "$1"; __traq_preexec "echo hello"; __traq_precmd`,
+		"--", pluginPath)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("zsh failed: %v\n%s", err, out)
+	}
+
+	logBytes, err := os.ReadFile(filepath.Join(shellDir, "history.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "\tzsh\t") {
+		t.Errorf("log missing zsh shell marker: %s", logBytes)
+	}
+	if !strings.Contains(string(logBytes), "echo hello") {
+		t.Errorf("log missing command: %s", logBytes)
+	}
+}
+```
+
+- [ ] **Step 3: Run**
+
+Run: `go test ./internal/tracker/shellplugin -v`
+Expected: PASS (skipping zsh test on systems without zsh installed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/tracker/shellplugin/
+git commit -m "feat: zsh shell plugin"
+```
+
+---
+
+## Task 11: Fish plugin
+
+**Files:**
+- Modify: `internal/tracker/shellplugin/embed/traq.fish`
+- Create: `internal/tracker/shellplugin/plugin_fish_test.go`
+
+- [ ] **Step 1: Write the fish plugin**
+
+Replace `internal/tracker/shellplugin/embed/traq.fish`:
+
+```fish
+# Traq shell integration for fish.
+
+if set -q __TRAQ_LOADED
+    return
+end
+set -g __TRAQ_LOADED 1
+
+set -g __traq_dir (test -n "$XDG_DATA_HOME"; and echo "$XDG_DATA_HOME/traq/shell"; or echo "$HOME/.local/share/traq/shell")
+set -g __traq_marker "$__traq_dir/enabled"
+set -g __traq_log "$__traq_dir/history.log"
+set -g __traq_overflow "$__traq_dir/overflowed"
+set -g __traq_max_bytes 10485760
+
+function __traq_preexec --on-event fish_preexec
+    set -g __traq_cmd $argv[1]
+    set -g __traq_start (date +%s%N)
+end
+
+function __traq_postexec --on-event fish_postexec
+    set -l exit_code $status
+    test -f $__traq_marker; or return
+
+    if test -f $__traq_log
+        set -l size (wc -c < $__traq_log 2>/dev/null | string trim)
+        if test -n "$size"; and test $size -gt $__traq_max_bytes
+            touch $__traq_overflow
+            return
+        end
+    end
+
+    set -l duration_ms 0
+    if set -q __traq_start
+        set -l end (date +%s%N)
+        set duration_ms (math "($end - $__traq_start) / 1000000")
+    end
+
+    set -l tmux_ctx "-"
+    if set -q TMUX
+        set -l s (tmux display-message -p '#S' 2>/dev/null)
+        set -l w (tmux display-message -p '#I' 2>/dev/null)
+        test -n "$s"; and test -n "$w"; and set tmux_ctx "$s:$w"
+    end
+
+    set -l hostname (hostname -s 2>/dev/null; or echo "-")
+
+    # Escape: \ -> \\, then tab -> \t, newline -> \n
+    set -l cmd $__traq_cmd
+    set cmd (string replace -a '\\' '\\\\' -- $cmd)
+    set cmd (string replace -a \t '\\t' -- $cmd)
+    set cmd (string replace -a \n '\\n' -- $cmd)
+    if test (string length -- $cmd) -gt 4000
+        set cmd (string sub -l 4000 -- $cmd)"…"
+    end
+
+    mkdir -p $__traq_dir
+    printf '1\t%s\t%s\t%s\t%s\t%s\t%s\tfish\t%s\n' \
+        (date +%s) $exit_code $duration_ms $PWD $tmux_ctx $hostname $cmd \
+        >> $__traq_log
+end
+```
+
+- [ ] **Step 2: Add behavior test**
+
+Create `internal/tracker/shellplugin/plugin_fish_test.go`:
+
+```go
+//go:build !windows
+
+package shellplugin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFishPlugin_WritesLogLine(t *testing.T) {
+	if _, err := exec.LookPath("fish"); err != nil {
+		t.Skip("fish not installed")
+	}
+
+	home := t.TempDir()
+	shellDir := filepath.Join(home, ".local", "share", "traq", "shell")
+	if err := os.MkdirAll(shellDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shellDir, "enabled"), []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginPath := filepath.Join(home, "plugin.fish")
+	script, err := Script(Fish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, script, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("fish", "--no-config", "-c",
+		`source $argv[1]; emit fish_preexec "echo hello"; emit fish_postexec "echo hello"`,
+		pluginPath)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fish failed: %v\n%s", err, out)
+	}
+
+	logBytes, err := os.ReadFile(filepath.Join(shellDir, "history.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "\tfish\t") {
+		t.Errorf("log missing fish shell marker: %s", logBytes)
+	}
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/tracker/shellplugin/
+git commit -m "feat: fish shell plugin"
+```
+
+---
+
+## Task 12: PowerShell plugin
+
+**Files:**
+- Modify: `internal/tracker/shellplugin/embed/Traq.ps1`
+
+- [ ] **Step 1: Write the PowerShell plugin**
+
+Replace `internal/tracker/shellplugin/embed/Traq.ps1`:
+
+```powershell
+# Traq shell integration for PowerShell.
+
+if ($global:__TRAQ_LOADED) { return }
+$global:__TRAQ_LOADED = $true
+
+$script:__traq_dir = if ($env:XDG_DATA_HOME) {
+    Join-Path $env:XDG_DATA_HOME 'traq\shell'
+} else {
+    Join-Path $env:APPDATA 'traq\shell'
+}
+$script:__traq_marker  = Join-Path $__traq_dir 'enabled'
+$script:__traq_log     = Join-Path $__traq_dir 'history.log'
+$script:__traq_overflow = Join-Path $__traq_dir 'overflowed'
+$script:__traq_max_bytes = 10485760
+$script:__traq_start = 0
+$script:__traq_cmd = $null
+
+function __Traq-PreInvoke {
+    param($Command)
+    $script:__traq_cmd = $Command
+    $script:__traq_start = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+}
+
+function __Traq-Escape([string]$s) {
+    $s = $s -replace '\\', '\\'
+    $s = $s -replace "`t", '\t'
+    $s = $s -replace "`n", '\n'
+    if ($s.Length -gt 4000) { $s = $s.Substring(0, 4000) + '…' }
+    return $s
+}
+
+function __Traq-Record {
+    param([int]$ExitCode)
+    if (-not (Test-Path $script:__traq_marker)) { return }
+
+    if (Test-Path $script:__traq_log) {
+        $size = (Get-Item $script:__traq_log).Length
+        if ($size -gt $script:__traq_max_bytes) {
+            New-Item -Path $script:__traq_overflow -ItemType File -Force | Out-Null
+            return
+        }
+    }
+
+    $end = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+    $durationMs = if ($script:__traq_start) { $end - $script:__traq_start } else { 0 }
+
+    $tmuxCtx = '-'
+    if ($env:TMUX) {
+        $s = (tmux display-message -p '#S') 2>$null
+        $w = (tmux display-message -p '#I') 2>$null
+        if ($s -and $w) { $tmuxCtx = "${s}:${w}" }
+    }
+
+    $hostName = try { [System.Net.Dns]::GetHostName() } catch { '-' }
+    $cwd = (Get-Location).Path
+    $ts = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $cmdEscaped = __Traq-Escape $script:__traq_cmd
+
+    if (-not (Test-Path $script:__traq_dir)) {
+        New-Item -Path $script:__traq_dir -ItemType Directory -Force | Out-Null
+    }
+    $line = "1`t${ts}`t${ExitCode}`t${durationMs}`t${cwd}`t${tmuxCtx}`t${hostName}`tpowershell`t${cmdEscaped}"
+    Add-Content -Path $script:__traq_log -Value $line -Encoding UTF8
+}
+
+# Hook via prompt function override (simplest cross-version approach).
+$__traq_prompt_original = (Get-Item function:prompt).ScriptBlock
+function global:prompt {
+    $ec = $LASTEXITCODE
+    if ($script:__traq_cmd) {
+        __Traq-Record -ExitCode ([int]($ec -is [int] ? $ec : 0))
+        $script:__traq_cmd = $null
+    }
+    $hist = Get-History -Count 1
+    if ($hist) {
+        __Traq-PreInvoke $hist.CommandLine
+    }
+    & $__traq_prompt_original
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add internal/tracker/shellplugin/
+git commit -m "feat: PowerShell shell plugin"
+```
+
+---
+
+## Task 13: Overflow sentinel handling in UI
+
+**Files:**
+- Modify: `internal/service/shellsetup.go` (add `DismissOverflow()` and wire into app.go)
+- Modify: `app.go`
+- Modify: `frontend/src/api/client.ts`, `hooks.ts`
+- Modify: `frontend/src/components/settings/ShellIntegrationStrip.tsx`
+
+- [ ] **Step 1: Add service method**
+
+In `internal/service/shellsetup.go`:
+
+```go
+func (s *ShellSetupService) DismissOverflow() error {
+	if err := os.Remove(s.overflowPath()); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Wails binding**
+
+In `app.go`:
+
+```go
+func (a *App) DismissShellOverflow() error {
+	return a.ShellSetup.DismissOverflow()
+}
+```
+
+Regenerate bindings.
+
+- [ ] **Step 3: Frontend hook**
+
+In `frontend/src/api/hooks.ts`:
+
+```ts
+export function useDismissShellOverflow() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => DismissShellOverflow(),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['shellSetup'] }),
+  });
+}
+```
+
+- [ ] **Step 4: UI banner**
+
+In `ShellIntegrationStrip.tsx`, when `status.overflowed` is true show a dismissible warning banner above the status strip using the hook from step 3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/ app.go frontend/
+git commit -m "feat: dismissible overflow banner for shell plugin log"
+```
+
+---
+
+## Task 14: E2E + manual verification
+
+**Files:**
+- Create: `frontend/e2e/tests/shell-integration.spec.ts`
+
+- [ ] **Step 1: Write Playwright E2E**
+
+Create `frontend/e2e/tests/shell-integration.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Shell integration', () => {
+  test('install flow flips pill from Not installed to Active', async ({ page }) => {
+    await page.goto('http://localhost:34115/#/settings');
+    await page.getByText('Data Sources').click();
+    await page.getByText('Shell History').click();
+
+    const strip = page.locator('text=Shell integration').locator('..').locator('..');
+    await expect(strip.getByText('Not installed')).toBeVisible();
+
+    await strip.getByRole('button', { name: 'Install plugin' }).click();
+    await expect(strip.getByText('Active')).toBeVisible({ timeout: 10000 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the E2E**
+
+In one terminal: `wails dev -tags webkit2_41`
+In another: `cd frontend && npx playwright test shell-integration.spec.ts`
+
+Expected: PASS (with the caveat that `wails dev` must be running).
+
+- [ ] **Step 3: Manual verification checklist**
+
+Document these in a short `docs/plans/2026-04-21-shell-plugin-integration-manual-test.md` — run each before merging:
+
+1. **Bash + tmux on Ubuntu:** install via UI, open two tmux panes, run different commands in each; confirm both appear in Traq's Shell History within ~10 seconds.
+2. **Zsh on macOS:** same flow with zsh.
+3. **Fish:** same flow.
+4. **PowerShell on Windows:** install, run a few commands, verify capture.
+5. **Upgrade path:** with Shell History already enabled via file-reading, install plugin. Run 3 commands. Confirm no duplicates in Traq (spot-check by timestamp + command).
+6. **Uninstall:** capture rc file hash (`sha256sum ~/.bashrc`), install, uninstall, re-hash. Confirm byte-identical. Confirm `~/.local/share/traq/shell/plugin.bash` no longer exists.
+7. **Toggle capture:** install, disable Shell History in Settings, run 5 commands, re-enable. Confirm 5 commands are NOT captured (marker-gating works).
+8. **Overflow:** disable Shell History but keep plugin installed, write >10 MB of junk commands (in a loop), re-enable. Confirm banner appears; dismiss it.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add frontend/e2e/tests/shell-integration.spec.ts docs/plans/2026-04-21-shell-plugin-integration-manual-test.md
+git commit -m "test: E2E + manual verification plan for shell plugin integration"
+```
+
+---
+
+## Post-implementation
+
+- [ ] Run full test suites:
+  - `go test ./...`
+  - `cd frontend && npm test`
+  - `cd frontend && npx tsc --noEmit`
+- [ ] `wails build -tags webkit2_41` succeeds
+- [ ] Run the manual verification checklist end-to-end on at least one Linux machine with tmux
+- [ ] Update `docs/guide/settings.md` or equivalent user-facing docs with a short "Shell integration" paragraph
+- [ ] Open PR referencing this plan and the design doc

--- a/docs/superpowers/plans/2026-04-23-ai-coding-data-source.md
+++ b/docs/superpowers/plans/2026-04-23-ai-coding-data-source.md
@@ -1,0 +1,2608 @@
+# AI Coding Data Source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ingest Claude Code and opencode session activity as a new timeline lane in Traq, following the existing "parallel event lane" pattern (shell/git/browser).
+
+**Architecture:** Two source-specific plugins behind a common `AIPlugin` interface, an `AITracker` that polls them on the daemon's existing tick, SQLite-backed `ai_sessions` + `ai_events` tables, on-read block derivation (idle-gap + mtime rescue), a new `AIEvents` map on `TimelineGridData`, and a frontend lane that renders the blocks alongside shell/git events. No transcripts stored; no effect on AFK or focus-time metrics.
+
+**Tech Stack:** Go 1.21+, SQLite (`database/sql`), Wails v2 bindings, React 18 + TypeScript, Vitest, Go `testing`.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-ai-coding-data-source-design.md`
+
+---
+
+## File Structure
+
+**New files (backend):**
+- `internal/storage/ai.go` — CRUD: `UpsertAISession`, `InsertAIEvents`, `GetAISessionByFilePath`, `GetAIEventsInRange`, `GetMaxAIEventTimestamp`, `ListAISessionsForDate`.
+- `internal/storage/ai_test.go` — storage tests.
+- `internal/tracker/aiplugin/plugin.go` — `AIPlugin` interface, `AIEvent` struct.
+- `internal/tracker/aiplugin/plugin_claude.go` — Claude JSONL tailer.
+- `internal/tracker/aiplugin/plugin_claude_test.go`
+- `internal/tracker/aiplugin/plugin_opencode.go` — opencode SQLite reader.
+- `internal/tracker/aiplugin/plugin_opencode_test.go`
+- `internal/tracker/aiplugin/testdata/claude/<slug>/<session>.jsonl` — fixtures.
+- `internal/tracker/aiplugin/testdata/opencode/opencode.db` — fixture SQLite.
+- `internal/tracker/ai.go` — `AITracker` orchestration.
+- `internal/tracker/ai_test.go` — integration test.
+- `internal/service/ai.go` — `ListAISessions`, `GetAISession`, `GetAIActivityForDay` + display types + block derivation.
+- `internal/service/ai_test.go` — block derivation tests.
+
+**New files (frontend):**
+- `frontend/src/components/timeline/AIEventsLane.tsx`
+- `frontend/src/components/timeline/AIEventsLane.test.tsx`
+- `frontend/src/components/settings/AITrackingSection.tsx`
+
+**Modified files:**
+- `internal/storage/migrations.go` — add `applyMigration15`, bump `schemaVersion` to 15.
+- `internal/service/timeline_grid.go` — add `AIEvents` to `TimelineGridData`, populate from `GetAIActivityForDay`.
+- `internal/service/config.go` — add `AITrackingConfig`, extend `DataSourcesConfig`.
+- `internal/tracker/daemon.go` — instantiate `AITracker` in `NewDaemon`, call `ai.Poll()` in the tick loop.
+- `app.go` — `ListAISessions`, `GetAISession` Wails bindings.
+- `frontend/src/api/client.ts` — `api.ai.list`, `api.ai.get`.
+- `frontend/src/api/hooks.ts` — `useAISessions`, `useAISession`.
+- `frontend/src/components/timeline/useTimelineData.ts` — fold `aiEvents` into the view model.
+- `frontend/src/components/timeline/EventList.tsx` (or wherever shell/git lanes render) — render `AIEventsLane`.
+- `frontend/src/pages/SettingsPage.tsx` — mount `AITrackingSection`.
+
+---
+
+## Conventions Referenced
+
+- **Migrations:** `internal/storage/migrations.go` uses per-function `applyMigrationN`, chained in `Migrate()`. Bump `schemaVersion` const. Follow the shape of `applyMigration14`.
+- **Tracker registration:** see `internal/tracker/daemon.go:58` (`shell *ShellTracker` field), `daemon.go:89` (`NewShellTracker(...)` in `NewDaemon`), `daemon.go:373` (`d.shell.Poll(session.ID)` in the tick loop).
+- **Service layer shapes:** service methods return plain-type display structs (no `sql.NullString`). See `internal/service/timeline.go` `ScreenshotDisplay`.
+- **Wails bindings:** `app.go` — methods on `*App`. After adding, run `wails generate bindings` or let `wails dev` regenerate.
+- **Frontend API client:** `frontend/src/api/client.ts` is a thin wrapper; `frontend/src/api/hooks.ts` wraps in React Query.
+- **Frontend testing:** Vitest. Examples at `frontend/src/api/hooks.test.ts`, `frontend/src/components/timeline/useTimelineData.test.ts`.
+
+---
+
+## Phase 1 — Storage Layer
+
+### Task 1: Migration 15 — ai_sessions and ai_events tables
+
+**Files:**
+- Modify: `internal/storage/migrations.go`
+
+- [ ] **Step 1: Bump schemaVersion and add migration chain entry**
+
+In `internal/storage/migrations.go`, change the constant:
+
+```go
+const schemaVersion = 15
+```
+
+And in `Migrate()`, after the existing `applyMigration14` block, add:
+
+```go
+	if currentVersion < 15 {
+		if err := s.applyMigration15(); err != nil {
+			return fmt.Errorf("migration 15 failed: %w", err)
+		}
+	}
+```
+
+- [ ] **Step 2: Implement applyMigration15**
+
+Append to `internal/storage/migrations.go`:
+
+```go
+func (s *Store) applyMigration15() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS ai_sessions (
+			id              TEXT PRIMARY KEY,
+			tool            TEXT NOT NULL,
+			project_dir     TEXT,
+			file_path       TEXT,
+			started_at      INTEGER NOT NULL,
+			last_event_at   INTEGER NOT NULL,
+			event_count     INTEGER NOT NULL DEFAULT 0,
+			source_offset   INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE INDEX IF NOT EXISTS idx_ai_sessions_last_event ON ai_sessions(last_event_at);
+		CREATE INDEX IF NOT EXISTS idx_ai_sessions_file_path   ON ai_sessions(file_path);
+
+		CREATE TABLE IF NOT EXISTS ai_events (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id   TEXT NOT NULL REFERENCES ai_sessions(id) ON DELETE CASCADE,
+			tool         TEXT NOT NULL,
+			kind         TEXT NOT NULL,
+			timestamp    INTEGER NOT NULL,
+			project_dir  TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_ai_events_ts      ON ai_events(timestamp);
+		CREATE INDEX IF NOT EXISTS idx_ai_events_session ON ai_events(session_id);
+		CREATE INDEX IF NOT EXISTS idx_ai_events_tool_ts ON ai_events(tool, timestamp);
+	`)
+	return err
+}
+```
+
+- [ ] **Step 3: Run existing migration tests**
+
+Run: `go test ./internal/storage/ -run TestMigrate -v`
+Expected: PASS (no migration test may exist — if so, confirm the package still builds: `go build ./internal/storage/`).
+
+- [ ] **Step 4: Verify migration from a fresh DB**
+
+Add this targeted test to `internal/storage/ai_test.go` (create the file):
+
+```go
+package storage
+
+import (
+	"testing"
+)
+
+func TestMigration15CreatesAITables(t *testing.T) {
+	store := newTestStore(t)
+	defer store.Close()
+
+	var count int
+	err := store.db.QueryRow(`
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type='table' AND name IN ('ai_sessions','ai_events')
+	`).Scan(&count)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 AI tables, got %d", count)
+	}
+}
+```
+
+Run: `go test ./internal/storage/ -run TestMigration15 -v`
+Expected: PASS
+
+(If `newTestStore` doesn't exist in this package, check `internal/storage/*_test.go` for the existing helper name — probably `NewTestStore` or similar — and swap it in.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/migrations.go internal/storage/ai_test.go
+git commit -m "feat(storage): migration 15 adds ai_sessions and ai_events tables"
+```
+
+---
+
+### Task 2: Storage CRUD — ai_sessions
+
+**Files:**
+- Create: `internal/storage/ai.go`
+- Modify: `internal/storage/ai_test.go`
+
+- [ ] **Step 1: Write failing tests for AISession CRUD**
+
+Append to `internal/storage/ai_test.go`:
+
+```go
+func TestUpsertAISessionInsertsAndUpdates(t *testing.T) {
+	store := newTestStore(t)
+	defer store.Close()
+
+	s := &AISession{
+		ID:          "sess-1",
+		Tool:        "claude",
+		ProjectDir:  "/home/u/repo",
+		FilePath:    "/home/u/.claude/projects/-home-u-repo/sess-1.jsonl",
+		StartedAt:   1700000000,
+		LastEventAt: 1700000100,
+		EventCount:  5,
+		SourceOffset: 2048,
+	}
+	if err := store.UpsertAISession(s); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	got, err := store.GetAISessionByFilePath(s.FilePath)
+	if err != nil || got == nil {
+		t.Fatalf("get after insert: got=%v err=%v", got, err)
+	}
+	if got.EventCount != 5 || got.SourceOffset != 2048 {
+		t.Fatalf("mismatched fields: %+v", got)
+	}
+
+	s.EventCount = 9
+	s.SourceOffset = 4096
+	s.LastEventAt = 1700000200
+	if err := store.UpsertAISession(s); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	got, _ = store.GetAISessionByFilePath(s.FilePath)
+	if got.EventCount != 9 || got.SourceOffset != 4096 {
+		t.Fatalf("update did not apply: %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/storage/ -run TestUpsertAISession -v`
+Expected: FAIL (compile error — `AISession`, `UpsertAISession`, `GetAISessionByFilePath` undefined).
+
+- [ ] **Step 3: Implement the types and methods**
+
+Create `internal/storage/ai.go`:
+
+```go
+package storage
+
+import "database/sql"
+
+type AISession struct {
+	ID           string
+	Tool         string
+	ProjectDir   string
+	FilePath     string
+	StartedAt    int64
+	LastEventAt  int64
+	EventCount   int
+	SourceOffset int64
+}
+
+type AIEvent struct {
+	ID         int64
+	SessionID  string
+	Tool       string
+	Kind       string
+	Timestamp  int64
+	ProjectDir string
+}
+
+func (s *Store) UpsertAISession(sess *AISession) error {
+	_, err := s.db.Exec(`
+		INSERT INTO ai_sessions (id, tool, project_dir, file_path, started_at, last_event_at, event_count, source_offset)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			project_dir   = excluded.project_dir,
+			file_path     = excluded.file_path,
+			last_event_at = excluded.last_event_at,
+			event_count   = excluded.event_count,
+			source_offset = excluded.source_offset
+	`, sess.ID, sess.Tool, nullableStr(sess.ProjectDir), nullableStr(sess.FilePath),
+		sess.StartedAt, sess.LastEventAt, sess.EventCount, sess.SourceOffset)
+	return err
+}
+
+func (s *Store) GetAISessionByFilePath(path string) (*AISession, error) {
+	row := s.db.QueryRow(`
+		SELECT id, tool, COALESCE(project_dir,''), COALESCE(file_path,''),
+		       started_at, last_event_at, event_count, source_offset
+		FROM ai_sessions WHERE file_path = ?
+	`, path)
+	var out AISession
+	err := row.Scan(&out.ID, &out.Tool, &out.ProjectDir, &out.FilePath,
+		&out.StartedAt, &out.LastEventAt, &out.EventCount, &out.SourceOffset)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func nullableStr(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `go test ./internal/storage/ -run TestUpsertAISession -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/ai.go internal/storage/ai_test.go
+git commit -m "feat(storage): UpsertAISession + GetAISessionByFilePath"
+```
+
+---
+
+### Task 3: Storage CRUD — ai_events
+
+**Files:**
+- Modify: `internal/storage/ai.go`
+- Modify: `internal/storage/ai_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/storage/ai_test.go`:
+
+```go
+func TestInsertAndQueryAIEvents(t *testing.T) {
+	store := newTestStore(t)
+	defer store.Close()
+
+	s := &AISession{ID: "sess-1", Tool: "claude", StartedAt: 1000, LastEventAt: 1000}
+	if err := store.UpsertAISession(s); err != nil {
+		t.Fatal(err)
+	}
+
+	events := []AIEvent{
+		{SessionID: "sess-1", Tool: "claude", Kind: "user_prompt", Timestamp: 1010},
+		{SessionID: "sess-1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1020},
+		{SessionID: "sess-1", Tool: "claude", Kind: "tool_use", Timestamp: 1030},
+	}
+	if err := store.InsertAIEvents(events); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	got, err := store.GetAIEventsInRange(1000, 2000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(got))
+	}
+
+	maxTs, err := store.GetMaxAIEventTimestamp("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if maxTs != 1030 {
+		t.Fatalf("expected max ts 1030, got %d", maxTs)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `go test ./internal/storage/ -run TestInsertAndQueryAIEvents -v`
+Expected: FAIL (undefined methods).
+
+- [ ] **Step 3: Implement methods**
+
+Append to `internal/storage/ai.go`:
+
+```go
+func (s *Store) InsertAIEvents(events []AIEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.Prepare(`
+		INSERT INTO ai_events (session_id, tool, kind, timestamp, project_dir)
+		VALUES (?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+	for _, e := range events {
+		if _, err := stmt.Exec(e.SessionID, e.Tool, e.Kind, e.Timestamp, nullableStr(e.ProjectDir)); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *Store) GetAIEventsInRange(startUnix, endUnix int64) ([]AIEvent, error) {
+	rows, err := s.db.Query(`
+		SELECT id, session_id, tool, kind, timestamp, COALESCE(project_dir,'')
+		FROM ai_events
+		WHERE timestamp BETWEEN ? AND ?
+		ORDER BY tool, session_id, timestamp
+	`, startUnix, endUnix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AIEvent
+	for rows.Next() {
+		var e AIEvent
+		if err := rows.Scan(&e.ID, &e.SessionID, &e.Tool, &e.Kind, &e.Timestamp, &e.ProjectDir); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetMaxAIEventTimestamp(tool string) (int64, error) {
+	var maxTs sql.NullInt64
+	err := s.db.QueryRow(`SELECT MAX(timestamp) FROM ai_events WHERE tool = ?`, tool).Scan(&maxTs)
+	if err != nil {
+		return 0, err
+	}
+	if !maxTs.Valid {
+		return 0, nil
+	}
+	return maxTs.Int64, nil
+}
+
+func (s *Store) ListAISessionsForDate(startUnix, endUnix int64) ([]AISession, error) {
+	rows, err := s.db.Query(`
+		SELECT DISTINCT s.id, s.tool, COALESCE(s.project_dir,''), COALESCE(s.file_path,''),
+		       s.started_at, s.last_event_at, s.event_count, s.source_offset
+		FROM ai_sessions s
+		JOIN ai_events e ON e.session_id = s.id
+		WHERE e.timestamp BETWEEN ? AND ?
+		ORDER BY s.last_event_at DESC
+	`, startUnix, endUnix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AISession
+	for rows.Next() {
+		var s AISession
+		if err := rows.Scan(&s.ID, &s.Tool, &s.ProjectDir, &s.FilePath,
+			&s.StartedAt, &s.LastEventAt, &s.EventCount, &s.SourceOffset); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `go test ./internal/storage/ -run TestInsertAndQueryAIEvents -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/storage/ai.go internal/storage/ai_test.go
+git commit -m "feat(storage): InsertAIEvents, GetAIEventsInRange, ListAISessionsForDate, GetMaxAIEventTimestamp"
+```
+
+---
+
+## Phase 2 — Plugin Layer
+
+### Task 4: AIPlugin interface and shared AIEvent type
+
+**Files:**
+- Create: `internal/tracker/aiplugin/plugin.go`
+
+- [ ] **Step 1: Create the interface file**
+
+Create `internal/tracker/aiplugin/plugin.go`:
+
+```go
+// Package aiplugin defines the interface AI coding session trackers implement.
+// Each plugin (claude, opencode) reads from an external on-disk data source and
+// returns normalized events that the AITracker writes to storage.
+package aiplugin
+
+import (
+	"context"
+	"time"
+
+	"traq/internal/storage"
+)
+
+// AIEvent is the in-memory representation of one atomic event from an AI tool's log.
+// It is not the same as storage.AIEvent (which has an int64 timestamp and DB ID).
+// The AITracker is responsible for converting + persisting these.
+type AIEvent struct {
+	Tool       string    // "claude" | "opencode"
+	SessionID  string    // tool's native session ID
+	ProjectDir string    // absolute path or "" if unknown
+	Timestamp  time.Time
+	Kind       string    // "user_prompt" | "assistant_turn" | "tool_use" | "message"
+	FilePath   string    // source JSONL path (claude) or "" (opencode)
+	// Offset is the byte position *after* this event within FilePath.
+	// Claude plugin sets this so AITracker can persist source_offset;
+	// opencode plugin leaves it zero.
+	Offset int64
+}
+
+// AIPlugin is a single source of AI activity.
+type AIPlugin interface {
+	// Name returns the short tool identifier ("claude" | "opencode").
+	Name() string
+
+	// Available returns true if this tool's data directory exists on disk.
+	// Plugins whose Available returns false are skipped for the session.
+	Available() bool
+
+	// Poll returns new events that have appeared since the plugin's last read.
+	// It uses the store to look up resume cursors (source_offset for claude,
+	// MAX(timestamp) for opencode). Implementations MUST be safe to call
+	// repeatedly on the same store without re-ingesting already-persisted events.
+	Poll(ctx context.Context, store *storage.Store) ([]AIEvent, error)
+}
+```
+
+- [ ] **Step 2: Build to confirm package compiles**
+
+Run: `go build ./internal/tracker/aiplugin/`
+Expected: no output (success).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/tracker/aiplugin/plugin.go
+git commit -m "feat(aiplugin): AIPlugin interface and shared AIEvent type"
+```
+
+---
+
+### Task 5: Claude plugin — JSONL fixture + parser skeleton
+
+**Files:**
+- Create: `internal/tracker/aiplugin/testdata/claude/-home-u-repo/sess-1.jsonl`
+- Create: `internal/tracker/aiplugin/plugin_claude.go`
+- Create: `internal/tracker/aiplugin/plugin_claude_test.go`
+
+- [ ] **Step 1: Write a minimal JSONL fixture**
+
+Create `internal/tracker/aiplugin/testdata/claude/-home-u-repo/sess-1.jsonl` (note: each line is one JSON document — no trailing comma or array wrapper):
+
+```
+{"type":"file-history-snapshot","messageId":"x","snapshot":{},"isSnapshotUpdate":false}
+{"type":"user","sessionId":"sess-1","cwd":"/home/u/repo","timestamp":"2026-04-23T10:00:00.000Z","message":{"role":"user","content":"hello"}}
+{"type":"assistant","sessionId":"sess-1","cwd":"/home/u/repo","timestamp":"2026-04-23T10:00:05.000Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}
+{"type":"assistant","sessionId":"sess-1","cwd":"/home/u/repo","timestamp":"2026-04-23T10:00:10.000Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash"}]}}
+```
+
+- [ ] **Step 2: Write the failing parser test**
+
+Create `internal/tracker/aiplugin/plugin_claude_test.go`:
+
+```go
+package aiplugin
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"traq/internal/storage"
+)
+
+func TestClaudePluginParsesFixtureJSONL(t *testing.T) {
+	root := filepath.Join("testdata", "claude")
+	p := NewClaudePlugin(root)
+	if !p.Available() {
+		t.Fatalf("fixture dir should make plugin available")
+	}
+
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	events, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events (snapshot skipped), got %d", len(events))
+	}
+
+	want := []struct {
+		kind string
+		ts   string
+	}{
+		{"user_prompt", "2026-04-23T10:00:00Z"},
+		{"assistant_turn", "2026-04-23T10:00:05Z"},
+		{"tool_use", "2026-04-23T10:00:10Z"},
+	}
+	for i, w := range want {
+		if events[i].Kind != w.kind {
+			t.Errorf("event[%d].Kind = %q, want %q", i, events[i].Kind, w.kind)
+		}
+		ts, _ := time.Parse(time.RFC3339, w.ts)
+		if !events[i].Timestamp.Equal(ts) {
+			t.Errorf("event[%d].Timestamp = %v, want %v", i, events[i].Timestamp, ts)
+		}
+		if events[i].SessionID != "sess-1" {
+			t.Errorf("event[%d].SessionID = %q", i, events[i].SessionID)
+		}
+		if events[i].ProjectDir != "/home/u/repo" {
+			t.Errorf("event[%d].ProjectDir = %q", i, events[i].ProjectDir)
+		}
+		if events[i].Tool != "claude" {
+			t.Errorf("event[%d].Tool = %q", i, events[i].Tool)
+		}
+	}
+}
+
+func TestClaudePluginResumesFromSourceOffset(t *testing.T) {
+	root := filepath.Join("testdata", "claude")
+	p := NewClaudePlugin(root)
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	// First poll ingests everything.
+	first, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) == 0 {
+		t.Fatal("expected events on first poll")
+	}
+	// Persist the returned events' source offset to simulate AITracker.
+	persistOffsetForTest(t, store, first)
+
+	// Second poll with nothing changed should return no new events.
+	second, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("expected 0 new events on repeat poll, got %d", len(second))
+	}
+}
+
+// persistOffsetForTest mimics what AITracker does between polls: upsert the session
+// row with the last event's file Offset so the next Poll resumes from there.
+func persistOffsetForTest(t *testing.T, store *storage.Store, events []Event) {
+	t.Helper()
+	// implemented once plugin is in place — see plugin_claude.go
+	// for field names. Keep this helper in the test file.
+	last := events[len(events)-1]
+	sess := &storage.AISession{
+		ID:           last.SessionID,
+		Tool:         last.Tool,
+		ProjectDir:   last.ProjectDir,
+		FilePath:     last.FilePath,
+		StartedAt:    events[0].Timestamp.Unix(),
+		LastEventAt:  last.Timestamp.Unix(),
+		EventCount:   len(events),
+		SourceOffset: last.Offset,
+	}
+	if err := store.UpsertAISession(sess); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Alias so the helper reads naturally. Keep only if it compiles cleanly;
+// otherwise replace Event with AIEvent everywhere.
+type Event = AIEvent
+```
+
+- [ ] **Step 3: Add in-memory test-store helper if missing**
+
+Check whether `storage.NewInMemoryTestStore` exists:
+
+Run: `grep -n "NewInMemoryTestStore\|newTestStore" internal/storage/*_test.go | head`
+
+If it doesn't exist, add an exported variant in `internal/storage/testing.go` (new file):
+
+```go
+package storage
+
+import "testing"
+
+// NewInMemoryTestStore returns a Store backed by an ephemeral on-disk SQLite DB
+// that's deleted at test end. Exported so other packages' tests can use it.
+func NewInMemoryTestStore(t *testing.T) *Store {
+	t.Helper()
+	// reuse whatever mechanism newTestStore uses; the simplest is:
+	store, err := NewStore(t.TempDir() + "/test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+```
+
+(If `NewStore`'s signature is different, use the correct constructor. Check `internal/storage/store.go`.)
+
+- [ ] **Step 4: Run test to verify failure**
+
+Run: `go test ./internal/tracker/aiplugin/ -run TestClaudePlugin -v`
+Expected: FAIL (undefined `NewClaudePlugin`).
+
+- [ ] **Step 5: Implement the Claude plugin**
+
+Create `internal/tracker/aiplugin/plugin_claude.go`:
+
+```go
+package aiplugin
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"traq/internal/storage"
+)
+
+const toolClaude = "claude"
+
+// ClaudePlugin tails Claude Code JSONL session files in <root>/<project-slug>/*.jsonl.
+type ClaudePlugin struct {
+	root string // ~/.claude/projects (or a fixture root in tests)
+}
+
+func NewClaudePlugin(root string) *ClaudePlugin {
+	return &ClaudePlugin{root: root}
+}
+
+func (p *ClaudePlugin) Name() string { return toolClaude }
+
+func (p *ClaudePlugin) Available() bool {
+	info, err := os.Stat(p.root)
+	return err == nil && info.IsDir()
+}
+
+// claudeLine matches the fields we care about in Claude's JSONL.
+// Other fields (message body, snapshot contents) are ignored by design.
+type claudeLine struct {
+	Type      string    `json:"type"`
+	SessionID string    `json:"sessionId"`
+	CWD       string    `json:"cwd"`
+	Timestamp time.Time `json:"timestamp"`
+	Message   struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+func (p *ClaudePlugin) Poll(ctx context.Context, store *storage.Store) ([]AIEvent, error) {
+	var out []AIEvent
+
+	matches, err := filepath.Glob(filepath.Join(p.root, "*", "*.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range matches {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+		events, err := p.readFile(path, store)
+		if err != nil {
+			// Don't fail the whole poll for one bad file — log would go here if we had a logger.
+			continue
+		}
+		out = append(out, events...)
+	}
+	return out, nil
+}
+
+func (p *ClaudePlugin) readFile(path string, store *storage.Store) ([]AIEvent, error) {
+	sess, err := store.GetAISessionByFilePath(path)
+	if err != nil {
+		return nil, err
+	}
+	var startOffset int64
+	if sess != nil {
+		startOffset = sess.SourceOffset
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(startOffset, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	var events []AIEvent
+	pos := startOffset
+	reader := bufio.NewReader(f)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			advance := int64(len(line))
+			pos += advance
+			if ev, ok := parseClaudeLine(line, path, pos); ok {
+				events = append(events, ev)
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return events, err
+		}
+	}
+	return events, nil
+}
+
+func parseClaudeLine(line []byte, filePath string, offsetAfter int64) (AIEvent, bool) {
+	var cl claudeLine
+	if err := json.Unmarshal(line, &cl); err != nil {
+		return AIEvent{}, false
+	}
+	kind := claudeKind(&cl)
+	if kind == "" {
+		return AIEvent{}, false
+	}
+	if cl.SessionID == "" || cl.Timestamp.IsZero() {
+		return AIEvent{}, false
+	}
+	return AIEvent{
+		Tool:       toolClaude,
+		SessionID:  cl.SessionID,
+		ProjectDir: cl.CWD,
+		Timestamp:  cl.Timestamp,
+		Kind:       kind,
+		FilePath:   filePath,
+		Offset:     offsetAfter,
+	}, true
+}
+
+func claudeKind(cl *claudeLine) string {
+	switch cl.Type {
+	case "user":
+		return "user_prompt"
+	case "assistant":
+		if containsToolUse(cl.Message.Content) {
+			return "tool_use"
+		}
+		return "assistant_turn"
+	default:
+		return ""
+	}
+}
+
+func containsToolUse(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var items []struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return false
+	}
+	for _, it := range items {
+		if it.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 6: Run tests to verify pass**
+
+Run: `go test ./internal/tracker/aiplugin/ -run TestClaudePlugin -v`
+Expected: PASS for both `TestClaudePluginParsesFixtureJSONL` and `TestClaudePluginResumesFromSourceOffset`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/tracker/aiplugin/plugin_claude.go \
+        internal/tracker/aiplugin/plugin_claude_test.go \
+        internal/tracker/aiplugin/testdata/claude \
+        internal/storage/testing.go
+git commit -m "feat(aiplugin): Claude plugin — JSONL tailer with offset resume"
+```
+
+---
+
+### Task 6: Claude plugin — corrupt-line resilience
+
+**Files:**
+- Modify: `internal/tracker/aiplugin/plugin_claude_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `plugin_claude_test.go`:
+
+```go
+func TestClaudePluginSkipsCorruptLines(t *testing.T) {
+	// Build a temp dir with one file containing valid + garbage + valid.
+	dir := t.TempDir()
+	projDir := filepath.Join(dir, "-tmp-proj")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(projDir, "sess-2.jsonl")
+	content := `{"type":"user","sessionId":"s","cwd":"/t","timestamp":"2026-04-23T10:00:00Z","message":{"role":"user","content":"a"}}
+NOT_JSON_GARBAGE
+{"type":"assistant","sessionId":"s","cwd":"/t","timestamp":"2026-04-23T10:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"b"}]}}
+`
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewClaudePlugin(dir)
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	events, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatalf("poll returned error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 valid events (garbage skipped), got %d", len(events))
+	}
+}
+```
+
+Also needs imports: add `"os"` to the test file if not already there.
+
+- [ ] **Step 2: Run test**
+
+Run: `go test ./internal/tracker/aiplugin/ -run TestClaudePluginSkipsCorruptLines -v`
+Expected: PASS (already handled by `parseClaudeLine` returning `ok=false` on unmarshal error).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/tracker/aiplugin/plugin_claude_test.go
+git commit -m "test(aiplugin): claude plugin skips corrupt JSONL lines"
+```
+
+---
+
+### Task 7: opencode plugin — SQLite reader
+
+**Files:**
+- Create: `internal/tracker/aiplugin/plugin_opencode.go`
+- Create: `internal/tracker/aiplugin/plugin_opencode_test.go`
+- Create: `internal/tracker/aiplugin/testdata/opencode/schema.sql` (used to build fixture DB at test time)
+
+- [ ] **Step 1: Write the fixture DB schema**
+
+Create `internal/tracker/aiplugin/testdata/opencode/schema.sql`:
+
+```sql
+CREATE TABLE project (
+	id text PRIMARY KEY,
+	worktree text NOT NULL,
+	vcs text,
+	name text,
+	icon_url text,
+	icon_color text,
+	time_created integer NOT NULL,
+	time_updated integer NOT NULL,
+	time_initialized integer,
+	sandboxes text NOT NULL,
+	commands text
+);
+
+CREATE TABLE session (
+	id text PRIMARY KEY,
+	project_id text NOT NULL,
+	parent_id text,
+	slug text NOT NULL,
+	directory text NOT NULL,
+	title text NOT NULL,
+	version text NOT NULL,
+	time_created integer NOT NULL,
+	time_updated integer NOT NULL
+);
+
+CREATE TABLE message (
+	id text PRIMARY KEY,
+	session_id text NOT NULL,
+	time_created integer NOT NULL,
+	time_updated integer NOT NULL,
+	data text NOT NULL
+);
+```
+
+(Only includes columns the plugin reads. The real DB has more; ignoring them is fine.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `internal/tracker/aiplugin/plugin_opencode_test.go`:
+
+```go
+package aiplugin
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"traq/internal/storage"
+)
+
+func buildOpencodeFixtureDB(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "opencode.db")
+
+	schemaBytes, err := os.ReadFile(filepath.Join("testdata", "opencode", "schema.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(string(schemaBytes)); err != nil {
+		t.Fatalf("schema exec: %v", err)
+	}
+
+	// Timestamps in milliseconds (matches real opencode).
+	_, err = db.Exec(`
+		INSERT INTO project (id, worktree, time_created, time_updated, sandboxes)
+		VALUES ('proj-1', '/home/u/repo', 1700000000000, 1700000000000, '[]');
+		INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+		VALUES ('ses_abc', 'proj-1', 'slug', '/home/u/repo', 't', '1', 1700000000000, 1700000030000);
+		INSERT INTO message (id, session_id, time_created, time_updated, data)
+		VALUES
+			('m1', 'ses_abc', 1700000010000, 1700000010000, '{}'),
+			('m2', 'ses_abc', 1700000020000, 1700000020000, '{}'),
+			('m3', 'ses_abc', 1700000030000, 1700000030000, '{}');
+	`)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return dbPath
+}
+
+func TestOpenCodePluginReadsMessages(t *testing.T) {
+	dbPath := buildOpencodeFixtureDB(t)
+	p := NewOpenCodePlugin(dbPath)
+	if !p.Available() {
+		t.Fatal("plugin should be available with fixture DB")
+	}
+
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	events, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+	for _, e := range events {
+		if e.Tool != "opencode" {
+			t.Errorf("Tool=%q", e.Tool)
+		}
+		if e.SessionID != "ses_abc" {
+			t.Errorf("SessionID=%q", e.SessionID)
+		}
+		if e.ProjectDir != "/home/u/repo" {
+			t.Errorf("ProjectDir=%q", e.ProjectDir)
+		}
+		if e.Kind != "message" {
+			t.Errorf("Kind=%q", e.Kind)
+		}
+	}
+}
+
+func TestOpenCodePluginResumesByMaxTimestamp(t *testing.T) {
+	dbPath := buildOpencodeFixtureDB(t)
+	p := NewOpenCodePlugin(dbPath)
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	// First poll reads all 3 messages.
+	first, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 3 {
+		t.Fatalf("expected 3, got %d", len(first))
+	}
+
+	// Simulate AITracker persisting them.
+	var dbEvents []storage.AIEvent
+	for _, e := range first {
+		dbEvents = append(dbEvents, storage.AIEvent{
+			SessionID: e.SessionID, Tool: e.Tool, Kind: e.Kind,
+			Timestamp: e.Timestamp.Unix(), ProjectDir: e.ProjectDir,
+		})
+	}
+	if err := store.UpsertAISession(&storage.AISession{
+		ID: first[0].SessionID, Tool: "opencode",
+		ProjectDir:  first[0].ProjectDir,
+		StartedAt:   first[0].Timestamp.Unix(),
+		LastEventAt: first[len(first)-1].Timestamp.Unix(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertAIEvents(dbEvents); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second poll should see nothing new.
+	second, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("expected 0 new events, got %d", len(second))
+	}
+}
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `go test ./internal/tracker/aiplugin/ -run TestOpenCodePlugin -v`
+Expected: FAIL (undefined `NewOpenCodePlugin`).
+
+- [ ] **Step 4: Implement the plugin**
+
+Create `internal/tracker/aiplugin/plugin_opencode.go`:
+
+```go
+package aiplugin
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"traq/internal/storage"
+)
+
+const toolOpenCode = "opencode"
+
+// OpenCodePlugin reads message timestamps from opencode's SQLite database.
+// It opens the DB read-only and does not hold a long-lived connection.
+type OpenCodePlugin struct {
+	dbPath string
+}
+
+func NewOpenCodePlugin(dbPath string) *OpenCodePlugin {
+	return &OpenCodePlugin{dbPath: dbPath}
+}
+
+func (p *OpenCodePlugin) Name() string { return toolOpenCode }
+
+func (p *OpenCodePlugin) Available() bool {
+	info, err := os.Stat(p.dbPath)
+	return err == nil && !info.IsDir()
+}
+
+func (p *OpenCodePlugin) Poll(ctx context.Context, store *storage.Store) ([]AIEvent, error) {
+	sinceUnix, err := store.GetMaxAIEventTimestamp(toolOpenCode)
+	if err != nil {
+		return nil, err
+	}
+	// opencode stores milliseconds; convert the resume cursor.
+	sinceMs := sinceUnix * 1000
+
+	// sqlite3 driver: file: prefix with immutable=1 avoids locking the live DB.
+	dsn := "file:" + p.dbPath + "?mode=ro&immutable=1"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT m.session_id, s.directory, m.time_created
+		FROM message m
+		JOIN session s ON s.id = m.session_id
+		WHERE m.time_created > ?
+		ORDER BY m.time_created ASC
+	`, sinceMs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []AIEvent
+	for rows.Next() {
+		var sessionID, directory string
+		var tsMs int64
+		if err := rows.Scan(&sessionID, &directory, &tsMs); err != nil {
+			return nil, err
+		}
+		out = append(out, AIEvent{
+			Tool:       toolOpenCode,
+			SessionID:  sessionID,
+			ProjectDir: directory,
+			Timestamp:  time.Unix(0, tsMs*int64(time.Millisecond)),
+			Kind:       "message",
+		})
+	}
+	return out, rows.Err()
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `go test ./internal/tracker/aiplugin/ -run TestOpenCodePlugin -v`
+Expected: PASS for both tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/tracker/aiplugin/plugin_opencode.go \
+        internal/tracker/aiplugin/plugin_opencode_test.go \
+        internal/tracker/aiplugin/testdata/opencode/schema.sql
+git commit -m "feat(aiplugin): opencode plugin — SQLite reader with timestamp cursor"
+```
+
+---
+
+## Phase 3 — AITracker Orchestration
+
+### Task 8: AITracker — integration with plugins and storage
+
+**Files:**
+- Create: `internal/tracker/ai.go`
+- Create: `internal/tracker/ai_test.go`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `internal/tracker/ai_test.go`:
+
+```go
+package tracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"traq/internal/storage"
+	"traq/internal/tracker/aiplugin"
+)
+
+func TestAITrackerPersistsClaudeEvents(t *testing.T) {
+	// Build a Claude fixture dir.
+	root := t.TempDir()
+	proj := filepath.Join(root, "-home-u-repo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"type":"user","sessionId":"s","cwd":"/home/u/repo","timestamp":"2026-04-23T10:00:00Z","message":{"role":"user","content":"a"}}
+{"type":"assistant","sessionId":"s","cwd":"/home/u/repo","timestamp":"2026-04-23T10:00:05Z","message":{"role":"assistant","content":[{"type":"text","text":"b"}]}}
+`
+	path := filepath.Join(proj, "s.jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	tr := NewAITracker(store, []aiplugin.AIPlugin{aiplugin.NewClaudePlugin(root)})
+	if err := tr.Poll(); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	events, err := store.GetAIEventsInRange(0, 1<<62)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 persisted events, got %d", len(events))
+	}
+
+	sess, err := store.GetAISessionByFilePath(path)
+	if err != nil || sess == nil {
+		t.Fatalf("session not persisted: err=%v sess=%v", err, sess)
+	}
+	if sess.EventCount != 2 {
+		t.Errorf("EventCount=%d want 2", sess.EventCount)
+	}
+	if sess.SourceOffset == 0 {
+		t.Errorf("SourceOffset should be >0 after ingest")
+	}
+
+	// Second poll should be a no-op.
+	if err := tr.Poll(); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := store.GetAIEventsInRange(0, 1<<62)
+	if len(after) != 2 {
+		t.Fatalf("expected no duplicate ingest, got %d total events", len(after))
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/tracker/ -run TestAITrackerPersists -v`
+Expected: FAIL (undefined `NewAITracker`).
+
+- [ ] **Step 3: Implement AITracker**
+
+Create `internal/tracker/ai.go`:
+
+```go
+package tracker
+
+import (
+	"context"
+	"time"
+
+	"traq/internal/storage"
+	"traq/internal/tracker/aiplugin"
+)
+
+// AITracker polls a set of AIPlugins and persists the events they return.
+// It is safe to call Poll concurrently from at most one goroutine.
+type AITracker struct {
+	store   *storage.Store
+	plugins []aiplugin.AIPlugin
+}
+
+func NewAITracker(store *storage.Store, plugins []aiplugin.AIPlugin) *AITracker {
+	return &AITracker{store: store, plugins: plugins}
+}
+
+// Poll queries every available plugin once and writes new events to storage.
+// Errors from a single plugin do not stop other plugins.
+func (t *AITracker) Poll() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, p := range t.plugins {
+		if !p.Available() {
+			continue
+		}
+		events, err := p.Poll(ctx, t.store)
+		if err != nil {
+			// Log-if-we-had-a-logger — continue with other plugins.
+			continue
+		}
+		if len(events) == 0 {
+			continue
+		}
+		if err := t.persist(events); err != nil {
+			continue
+		}
+	}
+	return nil
+}
+
+// persist groups events by session, upserts the ai_sessions row (using the last
+// event's file offset as the new source_offset), then bulk-inserts ai_events.
+func (t *AITracker) persist(events []aiplugin.AIEvent) error {
+	// Group by (tool, sessionID). Events within a Poll() already arrive in
+	// order, but different sessions may be interleaved across files.
+	type key struct{ tool, session string }
+	groups := map[key][]aiplugin.AIEvent{}
+	order := []key{}
+	for _, e := range events {
+		k := key{e.Tool, e.SessionID}
+		if _, seen := groups[k]; !seen {
+			order = append(order, k)
+		}
+		groups[k] = append(groups[k], e)
+	}
+
+	for _, k := range order {
+		g := groups[k]
+		last := g[len(g)-1]
+
+		// Compute started_at by looking up existing session or using first event.
+		var startedAt int64
+		existing, err := t.store.GetAISessionByFilePath(last.FilePath)
+		if err == nil && existing != nil {
+			startedAt = existing.StartedAt
+		} else {
+			startedAt = g[0].Timestamp.Unix()
+		}
+
+		existingCount := 0
+		if existing != nil {
+			existingCount = existing.EventCount
+		}
+
+		sess := &storage.AISession{
+			ID:           last.SessionID,
+			Tool:         last.Tool,
+			ProjectDir:   last.ProjectDir,
+			FilePath:     last.FilePath,
+			StartedAt:    startedAt,
+			LastEventAt:  last.Timestamp.Unix(),
+			EventCount:   existingCount + len(g),
+			SourceOffset: last.Offset,
+		}
+		if err := t.store.UpsertAISession(sess); err != nil {
+			return err
+		}
+
+		var dbEvents []storage.AIEvent
+		for _, e := range g {
+			dbEvents = append(dbEvents, storage.AIEvent{
+				SessionID:  e.SessionID,
+				Tool:       e.Tool,
+				Kind:       e.Kind,
+				Timestamp:  e.Timestamp.Unix(),
+				ProjectDir: e.ProjectDir,
+			})
+		}
+		if err := t.store.InsertAIEvents(dbEvents); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `go test ./internal/tracker/ -run TestAITrackerPersists -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tracker/ai.go internal/tracker/ai_test.go
+git commit -m "feat(tracker): AITracker orchestrates plugins and persists events"
+```
+
+---
+
+### Task 9: Wire AITracker into the daemon
+
+**Files:**
+- Modify: `internal/tracker/daemon.go`
+
+- [ ] **Step 1: Add AITracker field + construction**
+
+In `internal/tracker/daemon.go`, find the `Daemon` struct (around line 50–70) and add a field next to `shell`:
+
+```go
+	ai      *AITracker
+```
+
+In `NewDaemon`, after `shell := NewShellTracker(...)` (around line 89), add:
+
+```go
+	// Home dir lookup — opencode DB lives at ~/.local/share/opencode/opencode.db,
+	// Claude sessions at ~/.claude/projects. If HOME isn't set, both plugins
+	// report Available()==false and the tracker becomes a no-op.
+	home, _ := os.UserHomeDir()
+	aiPlugins := []aiplugin.AIPlugin{
+		aiplugin.NewClaudePlugin(filepath.Join(home, ".claude", "projects")),
+		aiplugin.NewOpenCodePlugin(filepath.Join(home, ".local", "share", "opencode", "opencode.db")),
+	}
+	ai := NewAITracker(store, aiPlugins)
+```
+
+Then add `ai: ai,` to the struct literal returned by `NewDaemon`.
+
+Add import for `traq/internal/tracker/aiplugin`.
+
+- [ ] **Step 2: Call ai.Poll in the daemon tick loop**
+
+Find where `d.shell.Poll(session.ID)` is called (around line 373) and add below it:
+
+```go
+	// AI plugins are independent of the current Traq session (no session FK).
+	if err := d.ai.Poll(); err != nil {
+		// Non-fatal — continue the tick.
+	}
+```
+
+- [ ] **Step 3: Build and run existing daemon tests**
+
+Run: `go build ./... && go test ./internal/tracker/ -run TestDaemon -v`
+Expected: build succeeds, existing daemon tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/tracker/daemon.go
+git commit -m "feat(tracker): register AITracker in daemon poll loop"
+```
+
+---
+
+## Phase 4 — Service Layer (block derivation, display types)
+
+### Task 10: Display types and session listing
+
+**Files:**
+- Create: `internal/service/ai.go`
+- Create: `internal/service/ai_test.go`
+
+- [ ] **Step 1: Write failing test for session listing**
+
+Create `internal/service/ai_test.go`:
+
+```go
+package service
+
+import (
+	"testing"
+
+	"traq/internal/storage"
+)
+
+func TestListAISessionsForDate(t *testing.T) {
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	if err := store.UpsertAISession(&storage.AISession{
+		ID: "s1", Tool: "claude", ProjectDir: "/a/b",
+		StartedAt: 1700000000, LastEventAt: 1700000100, EventCount: 3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertAIEvents([]storage.AIEvent{
+		{SessionID: "s1", Tool: "claude", Kind: "user_prompt", Timestamp: 1700000000},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000050},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000100},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewAIService(store)
+	got, err := svc.ListAISessions("2023-11-14") // covers 1700000000 (UTC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(got))
+	}
+	if got[0].ProjectName != "b" {
+		t.Errorf("ProjectName=%q want %q", got[0].ProjectName, "b")
+	}
+	if got[0].Tool != "claude" {
+		t.Errorf("Tool=%q", got[0].Tool)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/service/ -run TestListAISessionsForDate -v`
+Expected: FAIL (undefined `NewAIService`).
+
+- [ ] **Step 3: Implement types and ListAISessions**
+
+Create `internal/service/ai.go`:
+
+```go
+package service
+
+import (
+	"path/filepath"
+	"time"
+
+	"traq/internal/storage"
+)
+
+// Default threshold between events before a block splits (30 minutes).
+const DefaultAIIdleGapSeconds = 30 * 60
+
+type AIBlockDisplay struct {
+	Tool        string `json:"tool"`
+	SessionID   string `json:"sessionId"`
+	ProjectDir  string `json:"projectDir"`
+	ProjectName string `json:"projectName"`
+	StartTime   int64  `json:"startTime"`
+	EndTime     int64  `json:"endTime"`
+	EventCount  int    `json:"eventCount"`
+	IsLive      bool   `json:"isLive"`
+}
+
+type AISessionDisplay struct {
+	ID          string `json:"id"`
+	Tool        string `json:"tool"`
+	ProjectName string `json:"projectName"`
+	ProjectDir  string `json:"projectDir"`
+	StartedAt   int64  `json:"startedAt"`
+	LastEventAt int64  `json:"lastEventAt"`
+	EventCount  int    `json:"eventCount"`
+}
+
+type AISessionDetail struct {
+	AISessionDisplay
+	FilePath string `json:"filePath"`
+}
+
+type AIService struct {
+	store          *storage.Store
+	idleGapSeconds int
+}
+
+func NewAIService(store *storage.Store) *AIService {
+	return &AIService{store: store, idleGapSeconds: DefaultAIIdleGapSeconds}
+}
+
+// SetIdleGapSeconds lets the config layer override the default at runtime.
+func (s *AIService) SetIdleGapSeconds(n int) {
+	if n > 0 {
+		s.idleGapSeconds = n
+	}
+}
+
+func (s *AIService) ListAISessions(date string) ([]AISessionDisplay, error) {
+	start, end, err := dayRangeUnix(date)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.store.ListAISessionsForDate(start, end)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AISessionDisplay, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, AISessionDisplay{
+			ID:          r.ID,
+			Tool:        r.Tool,
+			ProjectName: filepath.Base(r.ProjectDir),
+			ProjectDir:  r.ProjectDir,
+			StartedAt:   r.StartedAt,
+			LastEventAt: r.LastEventAt,
+			EventCount:  r.EventCount,
+		})
+	}
+	return out, nil
+}
+
+func (s *AIService) GetAISession(id string) (*AISessionDetail, error) {
+	sess, err := s.store.GetAISessionByID(id)
+	if err != nil || sess == nil {
+		return nil, err
+	}
+	return &AISessionDetail{
+		AISessionDisplay: AISessionDisplay{
+			ID:          sess.ID,
+			Tool:        sess.Tool,
+			ProjectName: filepath.Base(sess.ProjectDir),
+			ProjectDir:  sess.ProjectDir,
+			StartedAt:   sess.StartedAt,
+			LastEventAt: sess.LastEventAt,
+			EventCount:  sess.EventCount,
+		},
+		FilePath: sess.FilePath,
+	}, nil
+}
+
+// dayRangeUnix parses a YYYY-MM-DD date (in local time) and returns the
+// [startUnix, endUnix] pair covering that calendar day.
+func dayRangeUnix(date string) (int64, int64, error) {
+	t, err := time.ParseInLocation("2006-01-02", date, time.Local)
+	if err != nil {
+		return 0, 0, err
+	}
+	start := t.Unix()
+	end := t.Add(24 * time.Hour).Add(-time.Second).Unix()
+	return start, end, nil
+}
+```
+
+Also add `GetAISessionByID` to storage. Append to `internal/storage/ai.go`:
+
+```go
+func (s *Store) GetAISessionByID(id string) (*AISession, error) {
+	row := s.db.QueryRow(`
+		SELECT id, tool, COALESCE(project_dir,''), COALESCE(file_path,''),
+		       started_at, last_event_at, event_count, source_offset
+		FROM ai_sessions WHERE id = ?
+	`, id)
+	var out AISession
+	err := row.Scan(&out.ID, &out.Tool, &out.ProjectDir, &out.FilePath,
+		&out.StartedAt, &out.LastEventAt, &out.EventCount, &out.SourceOffset)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+```
+
+(`dayRangeUnix` may collide with a helper elsewhere — if so, rename to `aiDayRangeUnix` and update the two call sites.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/service/ -run TestListAISessionsForDate -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/ai.go internal/service/ai_test.go internal/storage/ai.go
+git commit -m "feat(service): AIService.ListAISessions + GetAISession"
+```
+
+---
+
+### Task 11: Block derivation — idle-gap splitting
+
+**Files:**
+- Modify: `internal/service/ai.go`
+- Modify: `internal/service/ai_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/service/ai_test.go`:
+
+```go
+func TestDeriveAIBlocksSplitsOnIdleGap(t *testing.T) {
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	_ = store.UpsertAISession(&storage.AISession{ID: "s1", Tool: "claude", StartedAt: 0, LastEventAt: 0})
+	// Events: cluster 1 (0, 60, 120) ... gap ... cluster 2 (4000, 4060)
+	// With default 1800s gap, that's two blocks.
+	events := []storage.AIEvent{
+		{SessionID: "s1", Tool: "claude", Kind: "user_prompt", Timestamp: 1700000000},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000060},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000120},
+		{SessionID: "s1", Tool: "claude", Kind: "user_prompt", Timestamp: 1700004000},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700004060},
+	}
+	_ = store.InsertAIEvents(events)
+
+	svc := NewAIService(store)
+	blocks, err := svc.deriveBlocks(1700000000, 1700100000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks after gap split, got %d", len(blocks))
+	}
+	if blocks[0].SessionID != "s1" || blocks[1].SessionID != "s1" {
+		t.Errorf("both blocks should reference s1")
+	}
+	if blocks[0].EventCount != 3 || blocks[1].EventCount != 2 {
+		t.Errorf("counts: %d, %d", blocks[0].EventCount, blocks[1].EventCount)
+	}
+}
+
+func TestDeriveAIBlocksSplitsPerSession(t *testing.T) {
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	_ = store.UpsertAISession(&storage.AISession{ID: "s1", Tool: "claude", StartedAt: 0, LastEventAt: 0})
+	_ = store.UpsertAISession(&storage.AISession{ID: "s2", Tool: "claude", StartedAt: 0, LastEventAt: 0})
+	// Two concurrent sessions interleaved in time.
+	_ = store.InsertAIEvents([]storage.AIEvent{
+		{SessionID: "s1", Tool: "claude", Kind: "user_prompt", Timestamp: 1700000000},
+		{SessionID: "s2", Tool: "claude", Kind: "user_prompt", Timestamp: 1700000010},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000020},
+		{SessionID: "s2", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000030},
+	})
+
+	svc := NewAIService(store)
+	blocks, err := svc.deriveBlocks(0, 1<<62)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 per-session blocks, got %d", len(blocks))
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/service/ -run TestDeriveAIBlocks -v`
+Expected: FAIL (`deriveBlocks` undefined).
+
+- [ ] **Step 3: Implement deriveBlocks**
+
+Append to `internal/service/ai.go`:
+
+```go
+// blockTailPadSeconds pads the end of every block so single-event blocks
+// are visually non-zero on the timeline.
+const blockTailPadSeconds = 30
+
+func (s *AIService) deriveBlocks(startUnix, endUnix int64) ([]AIBlockDisplay, error) {
+	events, err := s.store.GetAIEventsInRange(startUnix, endUnix)
+	if err != nil {
+		return nil, err
+	}
+	if len(events) == 0 {
+		return nil, nil
+	}
+
+	// Group by (tool, sessionID) in encounter order. We cannot rely on the DB
+	// ordering for blocks — we need the original per-session sequence, which
+	// GetAIEventsInRange already provides by ordering on (tool, session_id, timestamp).
+	sessionRows := map[string]storage.AISession{}
+	blocks := []AIBlockDisplay{}
+
+	var current *AIBlockDisplay
+	var prevSessionKey string
+	var prevTs int64
+
+	flush := func() {
+		if current == nil {
+			return
+		}
+		current.EndTime += blockTailPadSeconds
+		blocks = append(blocks, *current)
+		current = nil
+	}
+
+	for _, e := range events {
+		key := e.Tool + "|" + e.SessionID
+		gap := e.Timestamp - prevTs
+		if current == nil || key != prevSessionKey || gap > int64(s.idleGapSeconds) {
+			flush()
+
+			// Lazy-load the session row to resolve project_dir / file_path.
+			row, ok := sessionRows[e.SessionID]
+			if !ok {
+				rp, _ := s.store.GetAISessionByID(e.SessionID)
+				if rp != nil {
+					row = *rp
+					sessionRows[e.SessionID] = row
+				}
+			}
+
+			projectDir := e.ProjectDir
+			if projectDir == "" {
+				projectDir = row.ProjectDir
+			}
+
+			current = &AIBlockDisplay{
+				Tool:        e.Tool,
+				SessionID:   e.SessionID,
+				ProjectDir:  projectDir,
+				ProjectName: filepath.Base(projectDir),
+				StartTime:   e.Timestamp,
+				EndTime:     e.Timestamp,
+				EventCount:  0,
+				IsLive:      false,
+			}
+		}
+		current.EndTime = e.Timestamp
+		current.EventCount++
+		prevSessionKey = key
+		prevTs = e.Timestamp
+	}
+	flush()
+
+	// Apply live-file rescue: for claude blocks whose session file was
+	// modified recently, mark IsLive. (The split decision above has already
+	// been made by this point, so rescue only affects the flag — future
+	// extension can merge adjacent blocks when IsLive is true.)
+	s.applyLiveFileRescue(blocks, sessionRows)
+
+	return blocks, nil
+}
+
+func (s *AIService) applyLiveFileRescue(blocks []AIBlockDisplay, sessionRows map[string]storage.AISession) {
+	threshold := time.Duration(s.idleGapSeconds/3) * time.Second
+	now := time.Now()
+	for i, b := range blocks {
+		if b.Tool != "claude" {
+			continue
+		}
+		row, ok := sessionRows[b.SessionID]
+		if !ok || row.FilePath == "" {
+			continue
+		}
+		info, err := osStat(row.FilePath)
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) < threshold {
+			blocks[i].IsLive = true
+		}
+	}
+}
+```
+
+Add at the top of `ai.go` (package-level indirection for testability):
+
+```go
+import "os"
+
+var osStat = os.Stat
+```
+
+Merge that import into the existing import block.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/service/ -run TestDeriveAIBlocks -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/ai.go internal/service/ai_test.go
+git commit -m "feat(service): derive AI activity blocks with idle-gap split + live-file rescue flag"
+```
+
+---
+
+### Task 12: GetAIActivityForDay (hour bucketing)
+
+**Files:**
+- Modify: `internal/service/ai.go`
+- Modify: `internal/service/ai_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/service/ai_test.go`:
+
+```go
+func TestGetAIActivityForDayBucketsByHour(t *testing.T) {
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	_ = store.UpsertAISession(&storage.AISession{ID: "s1", Tool: "claude", StartedAt: 0, LastEventAt: 0})
+	// Build events at 09:30, 09:45, 11:00 local time on 2026-04-23.
+	base, _ := time.ParseInLocation("2006-01-02 15:04", "2026-04-23 09:30", time.Local)
+	ts := []int64{
+		base.Unix(),
+		base.Add(15 * time.Minute).Unix(),
+		base.Add(90 * time.Minute).Unix(), // 11:00
+	}
+	var events []storage.AIEvent
+	for _, t := range ts {
+		events = append(events, storage.AIEvent{SessionID: "s1", Tool: "claude", Kind: "user_prompt", Timestamp: t})
+	}
+	_ = store.InsertAIEvents(events)
+
+	svc := NewAIService(store)
+	byHour, err := svc.GetAIActivityForDay("2026-04-23")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 09:30 + 09:45 are within default gap, so one block in hour 9.
+	// 11:00 is a separate block (gap > 30min), in hour 11.
+	if len(byHour[9]) != 1 {
+		t.Errorf("hour 9: expected 1 block, got %d", len(byHour[9]))
+	}
+	if len(byHour[11]) != 1 {
+		t.Errorf("hour 11: expected 1 block, got %d", len(byHour[11]))
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/service/ -run TestGetAIActivityForDay -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement GetAIActivityForDay**
+
+Append to `internal/service/ai.go`:
+
+```go
+func (s *AIService) GetAIActivityForDay(date string) (map[int][]AIBlockDisplay, error) {
+	start, end, err := dayRangeUnix(date)
+	if err != nil {
+		return nil, err
+	}
+	blocks, err := s.deriveBlocks(start, end)
+	if err != nil {
+		return nil, err
+	}
+	out := map[int][]AIBlockDisplay{}
+	for _, b := range blocks {
+		hr := time.Unix(b.StartTime, 0).In(time.Local).Hour()
+		out[hr] = append(out[hr], b)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/service/ -run TestGetAIActivityForDay -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/ai.go internal/service/ai_test.go
+git commit -m "feat(service): GetAIActivityForDay bucketing blocks by hour"
+```
+
+---
+
+### Task 13: Add AIEvents to TimelineGridData
+
+**Files:**
+- Modify: `internal/service/timeline_grid.go`
+
+- [ ] **Step 1: Find the grid-building function**
+
+Run: `grep -n "ShellEvents:\|GitEvents:" internal/service/timeline_grid.go | head`
+
+Identify the single place where `TimelineGridData` is populated (likely a builder function around the top of the file). Note the `*storage.Store` and other dependencies it already holds.
+
+- [ ] **Step 2: Add the field on the struct**
+
+In `internal/service/timeline_grid.go`, in the `TimelineGridData` struct definition (around line 12), add:
+
+```go
+	AIEvents        map[int][]AIBlockDisplay  `json:"aiEvents"`
+```
+
+- [ ] **Step 3: Populate the field**
+
+Locate the grid builder identified in Step 1. It has access to an `*storage.Store` — that's enough to construct an `AIService` inline (no refactor of the grid service required):
+
+```go
+	aiSvc := NewAIService(store)
+	aiEvents, err := aiSvc.GetAIActivityForDay(date)
+	if err != nil || aiEvents == nil {
+		aiEvents = map[int][]AIBlockDisplay{}
+	}
+	grid.AIEvents = aiEvents
+```
+
+(Empty map, not nil — the frontend expects an object, not `null`. Swallowing the error here matches the treatment of other optional lanes in this builder; surface it in logs if the surrounding code already does so for shell/git.)
+
+**Note:** if a later pass cleans up this builder, the `AIService` can be hoisted into the grid-service struct to match how `ShellTracker`/`GitTracker` are already wired. That refactor is out of scope for this task.
+
+- [ ] **Step 4: Build and run tests**
+
+Run: `go build ./... && go test ./internal/service/ -v`
+Expected: build succeeds, tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/timeline_grid.go
+git commit -m "feat(service): TimelineGridData exposes AIEvents map"
+```
+
+---
+
+## Phase 5 — Wails Bindings and Settings
+
+### Task 14: Wails bindings + settings config
+
+**Files:**
+- Modify: `app.go`
+- Modify: `internal/service/config.go`
+
+- [ ] **Step 1: Add AITrackingConfig**
+
+In `internal/service/config.go`, find `DataSourcesConfig` (around line 164). Add a new field and type:
+
+```go
+// in DataSourcesConfig:
+	AITracking *AITrackingConfig `json:"aiTracking"`
+```
+
+Add the new type:
+
+```go
+type AITrackingConfig struct {
+	Enabled         bool `json:"enabled"`
+	ClaudeEnabled   bool `json:"claudeEnabled"`
+	OpenCodeEnabled bool `json:"openCodeEnabled"`
+	IdleGapSeconds  int  `json:"idleGapSeconds"`
+}
+```
+
+In the `getDefaultDataSourcesConfig()` function (around line 819), add the default:
+
+```go
+		AITracking: &AITrackingConfig{
+			Enabled:         true,
+			ClaudeEnabled:   true,
+			OpenCodeEnabled: true,
+			IdleGapSeconds:  1800,
+		},
+```
+
+- [ ] **Step 2: Add the Wails bindings**
+
+In `app.go`, add next to the other timeline / data-source bindings:
+
+Inspect `app.go` once to confirm whether other services live as fields on `*App` (`a.configService`, `a.issueService`, etc.) or are constructed on demand:
+
+Run: `grep -n "func (a \\*App)" app.go | head -20` and look for a neighbor binding.
+
+**If on-demand construction is the norm** (services constructed in each method), add:
+
+```go
+func (a *App) ListAISessions(date string) ([]service.AISessionDisplay, error) {
+	return service.NewAIService(a.store).ListAISessions(date)
+}
+
+func (a *App) GetAISession(id string) (*service.AISessionDetail, error) {
+	return service.NewAIService(a.store).GetAISession(id)
+}
+```
+
+**If services are cached fields** (e.g. `a.timelineService.GetTimelineGridData(...)`): add an `aiService *service.AIService` field to the `App` struct, initialize it in `NewApp` (or wherever peer services are constructed) with `service.NewAIService(store)`, and call it as `a.aiService.ListAISessions(date)`.
+
+Pick one and use it consistently for both methods. Use the field `a.store` (or whatever the existing `*storage.Store` field is named — search `a\\.store\\|a\\.db` in app.go to confirm).
+
+- [ ] **Step 3: Build**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 4: Regenerate bindings**
+
+Run: `wails generate bindings -tags webkit2_41`
+
+Verify `frontend/wailsjs/go/main/App.d.ts` now contains `ListAISessions` and `GetAISession`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app.go internal/service/config.go frontend/wailsjs/
+git commit -m "feat(app): Wails bindings for AI sessions + AITrackingConfig defaults"
+```
+
+---
+
+## Phase 6 — Frontend
+
+### Task 15: API client + React Query hooks
+
+**Files:**
+- Modify: `frontend/src/api/client.ts`
+- Modify: `frontend/src/api/hooks.ts`
+
+- [ ] **Step 1: Add api.ai methods**
+
+In `frontend/src/api/client.ts`, add (alongside the existing data-source clients):
+
+```typescript
+import { ListAISessions, GetAISession } from '../../wailsjs/go/main/App';
+
+export const ai = {
+  list: (date: string) => ListAISessions(date),
+  get: (id: string) => GetAISession(id),
+};
+```
+
+Export as part of the `api` object:
+
+```typescript
+export const api = {
+  // ...existing fields...
+  ai,
+};
+```
+
+- [ ] **Step 2: Add React Query hooks**
+
+In `frontend/src/api/hooks.ts`:
+
+```typescript
+export function useAISessions(date: string) {
+  return useQuery({
+    queryKey: ['ai', 'sessions', date],
+    queryFn: () => api.ai.list(date),
+  });
+}
+
+export function useAISession(id: string | null) {
+  return useQuery({
+    queryKey: ['ai', 'session', id],
+    queryFn: () => api.ai.get(id!),
+    enabled: !!id,
+  });
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: success (no new type errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/client.ts frontend/src/api/hooks.ts
+git commit -m "feat(frontend): API client + React Query hooks for AI sessions"
+```
+
+---
+
+### Task 16: Fold AI events into useTimelineData
+
+**Files:**
+- Modify: `frontend/src/components/timeline/useTimelineData.ts`
+- Modify: `frontend/src/components/timeline/useTimelineData.test.ts`
+
+- [ ] **Step 1: Write a failing test that feeds aiEvents through**
+
+Open `frontend/src/components/timeline/useTimelineData.test.ts`. Find the `TimelineGridData`-shaped test fixture builder and add a new test block:
+
+```typescript
+  it('exposes aiEvents folded into per-hour view model', () => {
+    const aiBlock = {
+      tool: 'claude',
+      sessionId: 's1',
+      projectDir: '/home/u/repo',
+      projectName: 'repo',
+      startTime: Math.floor(new Date('2026-04-23T09:30:00Z').getTime() / 1000),
+      endTime: Math.floor(new Date('2026-04-23T09:45:00Z').getTime() / 1000),
+      eventCount: 5,
+      isLive: false,
+    };
+
+    const { result } = renderHook(() => useTimelineData(buildData({
+      hourlyGrid: {},
+      shellEvents: {},
+      aiEvents: { '9': [aiBlock] },
+    })));
+
+    const hour9 = result.current.hours.find(h => h.hour === 9);
+    expect(hour9?.aiBlocks?.length).toBe(1);
+    expect(hour9?.aiBlocks?.[0].tool).toBe('claude');
+  });
+```
+
+(`buildData` is the existing helper in that file. If its default fixture doesn't already have an `aiEvents` key, add `aiEvents: {}` to the default so other tests keep passing.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd frontend && npm test -- useTimelineData`
+Expected: FAIL (hook doesn't surface `aiBlocks`).
+
+- [ ] **Step 3: Update the hook**
+
+In `frontend/src/components/timeline/useTimelineData.ts`:
+
+1. Extend the per-hour view-model type to include `aiBlocks`:
+
+```typescript
+export interface HourViewModel {
+  hour: number;
+  // ...existing fields...
+  aiBlocks?: AIBlockDisplay[];
+}
+
+export interface AIBlockDisplay {
+  tool: string;
+  sessionId: string;
+  projectDir: string;
+  projectName: string;
+  startTime: number;
+  endTime: number;
+  eventCount: number;
+  isLive: boolean;
+}
+```
+
+2. In the reducer / builder that walks `data.shellEvents` (around line 174 per earlier grep), add an analogous loop for `data.aiEvents`:
+
+```typescript
+if (data.aiEvents) {
+  for (const [hourStr, blocks] of Object.entries(data.aiEvents)) {
+    const hour = Number(hourStr);
+    ensureHour(hour).aiBlocks = blocks as AIBlockDisplay[];
+  }
+}
+```
+
+3. Update the `TimelineGridData` TypeScript type (wherever it's defined — likely `frontend/src/types/` or auto-generated) to include the new `aiEvents` field. If it's auto-generated from Go bindings, it will already be present after Task 14.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd frontend && npm test -- useTimelineData`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/timeline/useTimelineData.ts \
+        frontend/src/components/timeline/useTimelineData.test.ts
+git commit -m "feat(frontend): fold AI events into timeline view model"
+```
+
+---
+
+### Task 17: AIEventsLane component
+
+**Files:**
+- Create: `frontend/src/components/timeline/AIEventsLane.tsx`
+- Create: `frontend/src/components/timeline/AIEventsLane.test.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `frontend/src/components/timeline/AIEventsLane.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AIEventsLane } from './AIEventsLane';
+
+describe('AIEventsLane', () => {
+  const blocks = [
+    {
+      tool: 'claude',
+      sessionId: 's1',
+      projectDir: '/home/u/traq',
+      projectName: 'traq',
+      startTime: 1700000000,
+      endTime: 1700000600,
+      eventCount: 4,
+      isLive: false,
+    },
+    {
+      tool: 'opencode',
+      sessionId: 's2',
+      projectDir: '/home/u/other',
+      projectName: 'other',
+      startTime: 1700000000,
+      endTime: 1700000300,
+      eventCount: 2,
+      isLive: false,
+    },
+  ];
+
+  it('renders one block per input', () => {
+    render(<AIEventsLane blocks={blocks} hour={0} />);
+    expect(screen.getAllByTestId('ai-block')).toHaveLength(2);
+  });
+
+  it('tags each block with its tool', () => {
+    render(<AIEventsLane blocks={blocks} hour={0} />);
+    const els = screen.getAllByTestId('ai-block');
+    expect(els[0]).toHaveAttribute('data-tool', 'claude');
+    expect(els[1]).toHaveAttribute('data-tool', 'opencode');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd frontend && npm test -- AIEventsLane`
+Expected: FAIL (component doesn't exist).
+
+- [ ] **Step 3: Implement the component**
+
+Create `frontend/src/components/timeline/AIEventsLane.tsx`:
+
+```tsx
+import { Bot, Sparkles } from 'lucide-react';
+import type { AIBlockDisplay } from './useTimelineData';
+
+interface AIEventsLaneProps {
+  blocks: AIBlockDisplay[];
+  hour: number;
+}
+
+// Project-color assignment: stable hash of projectName to a palette index.
+const PALETTE = [
+  'bg-indigo-500', 'bg-emerald-500', 'bg-amber-500',
+  'bg-rose-500', 'bg-sky-500', 'bg-violet-500',
+];
+
+function colorFor(name: string): string {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) | 0;
+  return PALETTE[Math.abs(h) % PALETTE.length];
+}
+
+export function AIEventsLane({ blocks, hour }: AIEventsLaneProps) {
+  if (!blocks || blocks.length === 0) return null;
+
+  return (
+    <div className="relative flex flex-col gap-0.5" data-hour={hour}>
+      {blocks.map((b) => {
+        const Icon = b.tool === 'claude' ? Sparkles : Bot;
+        return (
+          <div
+            key={`${b.tool}-${b.sessionId}-${b.startTime}`}
+            data-testid="ai-block"
+            data-tool={b.tool}
+            data-session-id={b.sessionId}
+            className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-white ${colorFor(b.projectName)}`}
+            title={`${b.tool} · ${b.projectName} · ${b.eventCount} events`}
+          >
+            <Icon className="h-3 w-3" aria-hidden />
+            <span className="truncate">{b.projectName}</span>
+            {b.isLive && <span className="ml-auto text-[10px] opacity-80">live</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd frontend && npm test -- AIEventsLane`
+Expected: PASS.
+
+- [ ] **Step 5: Mount the lane in the timeline grid**
+
+Find where shell / git lanes render per hour (search `shellEvents` usage in `EventList.tsx` or the grid component). Mount `AIEventsLane` in the same row container:
+
+```tsx
+{hour.aiBlocks && <AIEventsLane blocks={hour.aiBlocks} hour={hour.hour} />}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/timeline/AIEventsLane.tsx \
+        frontend/src/components/timeline/AIEventsLane.test.tsx \
+        frontend/src/components/timeline/EventList.tsx
+git commit -m "feat(frontend): AIEventsLane renders per-project AI activity blocks"
+```
+
+---
+
+### Task 18: Settings section
+
+**Files:**
+- Create: `frontend/src/components/settings/AITrackingSection.tsx`
+- Modify: `frontend/src/pages/SettingsPage.tsx`
+
+- [ ] **Step 1: Build the component**
+
+Create `frontend/src/components/settings/AITrackingSection.tsx`:
+
+```tsx
+import { useConfig, useUpdateConfig } from '../../api/hooks';
+
+export function AITrackingSection() {
+  const { data: config } = useConfig();
+  const update = useUpdateConfig();
+
+  const ai = config?.dataSources?.aiTracking;
+  if (!ai) return null;
+
+  const setField = (patch: Partial<typeof ai>) =>
+    update.mutate({
+      ...config!,
+      dataSources: {
+        ...config!.dataSources,
+        aiTracking: { ...ai, ...patch },
+      },
+    });
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-lg font-semibold">AI Coding Sessions</h2>
+      <p className="text-sm text-muted-foreground">
+        Track Claude Code and opencode session activity on the timeline. Only timestamps
+        are stored — prompts, responses, and tool arguments are never read.
+      </p>
+
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={ai.enabled}
+          onChange={(e) => setField({ enabled: e.target.checked })}
+        />
+        Enable AI tracking
+      </label>
+
+      <label className="flex items-center gap-2 pl-6">
+        <input
+          type="checkbox"
+          disabled={!ai.enabled}
+          checked={ai.claudeEnabled}
+          onChange={(e) => setField({ claudeEnabled: e.target.checked })}
+        />
+        Claude Code
+      </label>
+
+      <label className="flex items-center gap-2 pl-6">
+        <input
+          type="checkbox"
+          disabled={!ai.enabled}
+          checked={ai.openCodeEnabled}
+          onChange={(e) => setField({ openCodeEnabled: e.target.checked })}
+        />
+        opencode
+      </label>
+
+      <label className="flex flex-col gap-1 pt-2">
+        <span className="text-sm">Idle gap between blocks: {ai.idleGapSeconds / 60} minutes</span>
+        <input
+          type="range"
+          min={300}
+          max={3600}
+          step={60}
+          value={ai.idleGapSeconds}
+          onChange={(e) => setField({ idleGapSeconds: Number(e.target.value) })}
+        />
+      </label>
+    </section>
+  );
+}
+```
+
+(`useConfig` / `useUpdateConfig` must match the existing hook names — check `frontend/src/api/hooks.ts` and adjust.)
+
+- [ ] **Step 2: Mount in SettingsPage**
+
+In `frontend/src/pages/SettingsPage.tsx`, import and render `AITrackingSection` alongside the existing data-source sections.
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/settings/AITrackingSection.tsx \
+        frontend/src/pages/SettingsPage.tsx
+git commit -m "feat(frontend): settings section for AI tracking"
+```
+
+---
+
+## Phase 7 — End-to-End Verification
+
+### Task 19: Manual smoke test with wails dev
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `wails dev -tags webkit2_41`
+
+Expected: dev server on port 34115, frontend loads.
+
+- [ ] **Step 2: Verify a fresh user has no AI data**
+
+Open the Timeline page for today. Expected: no AI lane content, no crashes, no console errors about `aiEvents` being undefined.
+
+- [ ] **Step 3: Verify a user with real Claude sessions sees data**
+
+If you have `~/.claude/projects/` with recent sessions, wait for one daemon poll (≤30s), then reload the Timeline page.
+
+Expected: AI blocks appear in the AI lane for hours that had Claude activity, colored by project, with a Sparkles icon.
+
+- [ ] **Step 4: Verify the settings section renders**
+
+Navigate to Settings. Expected: "AI Coding Sessions" section renders with three checkboxes and the slider. Toggling persists after reload.
+
+- [ ] **Step 5: Check console for errors**
+
+Open DevTools. Expected: no errors referencing `ai`, `AIEventsLane`, or missing fields.
+
+- [ ] **Step 6: Commit the smoke-test checklist record if appropriate**
+
+No code change — just confirm everything works. If issues are found, open a new task rather than amending this plan.
+
+---
+
+## Spec Coverage Check
+
+Mapping spec requirements → tasks:
+
+| Spec section | Task(s) |
+|---|---|
+| Architecture / package layout | Tasks 4–8 |
+| Data model: `ai_sessions`, `ai_events` | Tasks 1–3 |
+| Cursoring (Claude offset, opencode max-ts) | Tasks 5, 7 |
+| No FK to `sessions` | Task 1 (schema) |
+| No activity/AFK input | Tasks 8, 13 (no wiring into AFK/SessionManager) |
+| Block derivation + idle-gap | Tasks 11, 12 |
+| Live-file mtime rescue | Task 11 |
+| Concurrent-session handling | Task 11 (per-session grouping test) |
+| `TimelineGridData.AIEvents` | Task 13 |
+| Service methods | Tasks 10–12 |
+| Wails bindings | Task 14 |
+| Frontend API + hooks | Task 15 |
+| Frontend view model | Task 16 |
+| Frontend lane component | Task 17 |
+| Settings config + UI | Tasks 14, 18 |
+| Privacy (no bodies read) | Tasks 5, 7 (parsers ignore content) |
+| Testing posture | Tasks 2, 3, 5–8, 10–12, 16, 17 |
+
+---
+
+## Notes on the `ai_coding` category
+
+The spec adds `"ai_coding"` to the analytics breakdown. That integration point (`DayStats.Breakdown`) was not reviewed during spec-writing and needs a follow-up task once the existing breakdown code is read in context. It is intentionally **not** in this plan — it's a small additive change that doesn't block any of the above, and batching it here would require guessing at the breakdown's current shape.
+
+Open a follow-up plan entry after Task 13 is complete to:
+- Read `internal/service/analytics.go` / timeline breakdown path.
+- Derive AI duration per day (sum of block durations).
+- Add a category entry under the existing breakdown map.

--- a/docs/superpowers/specs/2026-04-23-ai-coding-data-source-design.md
+++ b/docs/superpowers/specs/2026-04-23-ai-coding-data-source-design.md
@@ -1,0 +1,285 @@
+# AI Coding Data Source — Design
+
+**Date:** 2026-04-23
+**Status:** Approved for plan-writing
+**Scope:** Add Claude Code and opencode as first-class data sources in Traq, rendering on the timeline alongside existing shell/git/browser/file lanes.
+
+---
+
+## Goals
+
+1. Show when the user was engaged with Claude Code / opencode on the daily timeline.
+2. Group activity per tool + session + project, with concurrent sessions rendered as stacked blocks.
+3. Keep v1 minimal: no transcript storage, no cost/analytics page, no new AFK inputs.
+
+## Non-goals (v1)
+
+- Storing prompt text, assistant responses, tool-call arguments, diffs, token counts, or cost.
+- Dedicated AI analytics / usage page.
+- Feeding AI events into AFK / focus-time detection.
+- Cross-tool correlation (matching a Claude session to an opencode session in the same repo).
+- Prompt search or full-text indexing.
+- Live streaming updates (poll loop is sufficient).
+
+---
+
+## Architecture
+
+### Package layout
+
+```
+internal/tracker/
+├── ai.go                       # AITracker: poll plugins, write events, upsert ai_sessions
+└── aiplugin/
+    ├── plugin.go               # AIPlugin interface + shared AIEvent struct
+    ├── plugin_claude.go        # tail JSONL files in ~/.claude/projects/
+    ├── plugin_opencode.go      # query ~/.local/share/opencode/opencode.db
+    └── testdata/               # fixture JSONLs and fixture SQLite dbs
+
+internal/service/
+└── ai.go                       # ListAISessions, GetAISession, GetAIActivityForDay
+
+internal/storage/
+└── ai.go                       # CRUD for ai_sessions, ai_events
+```
+
+The tracker runs on the same poll loop as `ShellTracker` (`internal/tracker/daemon.go`). `AITracker` iterates its registered plugins, each of which returns new `AIEvent`s since its last cursor, and writes rows.
+
+### Plugin interface
+
+```go
+package aiplugin
+
+type AIEvent struct {
+    Tool       string    // "claude" | "opencode"
+    SessionID  string
+    ProjectDir string    // resolved cwd, "" if unknown
+    Timestamp  time.Time
+    Kind       string    // "user_prompt" | "assistant_turn" | "tool_use"
+    FilePath   string    // source JSONL path (claude) or "" (opencode)
+}
+
+type AIPlugin interface {
+    Name() string                                // "claude" | "opencode"
+    Available() bool                             // skip if tool's data dir isn't present
+    Poll(ctx context.Context, store *storage.Store) ([]AIEvent, error)
+}
+```
+
+Each plugin is responsible for its own resumption logic (see Data Model → cursoring).
+
+---
+
+## Data Model
+
+Migration 9 (schema version after current head):
+
+```sql
+CREATE TABLE ai_sessions (
+    id              TEXT PRIMARY KEY,            -- tool's native session ID
+    tool            TEXT NOT NULL,               -- 'claude' | 'opencode'
+    project_dir     TEXT,                        -- absolute path, may be NULL
+    file_path       TEXT,                        -- JSONL path (claude), NULL (opencode)
+    started_at      INTEGER NOT NULL,            -- unix epoch seconds
+    last_event_at   INTEGER NOT NULL,
+    event_count     INTEGER NOT NULL DEFAULT 0,
+    source_offset   INTEGER NOT NULL DEFAULT 0   -- bytes consumed from file_path
+);
+CREATE INDEX idx_ai_sessions_last_event ON ai_sessions(last_event_at);
+
+CREATE TABLE ai_events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id   TEXT NOT NULL REFERENCES ai_sessions(id) ON DELETE CASCADE,
+    tool         TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    timestamp    INTEGER NOT NULL,
+    project_dir  TEXT
+);
+CREATE INDEX idx_ai_events_ts      ON ai_events(timestamp);
+CREATE INDEX idx_ai_events_session ON ai_events(session_id);
+```
+
+### Cursoring (resume logic)
+
+No separate checkpoint file. Each plugin derives its cursor from the DB:
+
+- **Claude plugin.** Each JSONL file maps 1:1 to a session. Per poll: list all `~/.claude/projects/*/*.jsonl`. For each file, `SELECT source_offset FROM ai_sessions WHERE file_path = ?`, `Seek()` there, parse to EOF, write new events, `UPDATE ai_sessions SET source_offset = <new_pos>, last_event_at = ..., event_count = ...`. New files (no row) start at offset 0 and trigger an INSERT.
+- **opencode plugin.** Resume by `SELECT COALESCE(MAX(timestamp), 0) FROM ai_events WHERE tool = 'opencode'`. Query `opencode.db` for rows newer than that. Upsert `ai_sessions` rows from the result. No offset needed — the event table is the cursor.
+
+Self-healing: deleting Traq's DB triggers a full re-ingest on next poll. Deleting a source JSONL leaves orphan `ai_sessions` / `ai_events`; the session is marked "ended" because `file_path` no longer resolves on next poll (no further offset advances possible).
+
+### Relationship to existing `sessions`
+
+No foreign key. `ai_sessions` is a parallel activity track alongside `git_events`, `shell_commands`, `browser_visits`. Overlap between an AI session and Traq's work sessions is computed at query time via timestamp range.
+
+### Relationship to activity/AFK
+
+AI events **do not** feed `AFKDetector`, `SessionManager`, or any `DayStats` field (`TotalSeconds`, `LongestFocus`, `BreakCount`). An autonomous agent running while the user is AFK does not extend focus time. AI data is a **display-only** lane. Window focus continues to be the sole human-presence signal.
+
+---
+
+## Timeline block derivation
+
+Blocks are computed on read (same pattern as `ShellEvents`/`GitEvents` in `timeline_grid.go`), never materialized.
+
+### Algorithm (per day, in `service/ai.go`)
+
+```
+events := SELECT * FROM ai_events
+           WHERE timestamp BETWEEN <day_start> AND <day_end>
+           ORDER BY tool, session_id, timestamp
+
+for each (tool, session_id) group:
+    start a new block with first event
+    for each subsequent event:
+        gap := event.ts - prev.ts
+        if gap > IdleGapSeconds AND NOT session_is_live_mtime_check():
+            close current block; start new block
+        else:
+            extend current block to event.ts
+    close final block
+
+pad each block's end by 30s so single-event blocks are visible
+bucket blocks by hour for the grid (split blocks crossing hour boundaries)
+```
+
+### Idle-gap policy
+
+- Default `IdleGapSeconds = 1800` (30 min). Configurable in settings.
+- **Live-file rescue:** during derivation, for Claude sessions only, before splitting on a large gap between the last event and "now," `os.Stat` the JSONL. Concretely: if `time.Now() - mtime < IdleGapSeconds / 3`, the file was written to recently — treat the session as still live and do not split. This catches the "one long tool call, no intermediate events" case.
+- opencode has no equivalent file to stat; it relies on the threshold alone. Acceptable because opencode's DB writes are more granular.
+
+### Concurrent sessions
+
+Grouping by `session_id` before splitting produces independent block sequences per session. The frontend stacks overlapping blocks vertically within the single AI lane (decision: option A+D — one tool-agnostic lane with a tool icon per block).
+
+---
+
+## Service / API surface
+
+### Service (`internal/service/ai.go`)
+
+```go
+func (s *Service) ListAISessions(date string) ([]AISessionDisplay, error)
+func (s *Service) GetAISession(id string) (*AISessionDetail, error)
+func (s *Service) GetAIActivityForDay(date string) (map[int][]AIBlockDisplay, error)
+```
+
+### Display types
+
+```go
+type AIBlockDisplay struct {
+    Tool        string `json:"tool"`
+    SessionID   string `json:"sessionId"`
+    ProjectDir  string `json:"projectDir"`
+    ProjectName string `json:"projectName"`
+    StartTime   int64  `json:"startTime"`
+    EndTime     int64  `json:"endTime"`
+    EventCount  int    `json:"eventCount"`
+    IsLive      bool   `json:"isLive"`
+}
+
+type AISessionDisplay struct {
+    ID            string `json:"id"`
+    Tool          string `json:"tool"`
+    ProjectName   string `json:"projectName"`
+    ProjectDir    string `json:"projectDir"`
+    StartedAt     int64  `json:"startedAt"`
+    LastEventAt   int64  `json:"lastEventAt"`
+    EventCount    int    `json:"eventCount"`
+}
+
+type AISessionDetail struct {
+    AISessionDisplay
+    FilePath string `json:"filePath"` // for "open raw transcript"
+}
+```
+
+### Wails bindings (`app.go`)
+
+```go
+func (a *App) ListAISessions(date string) ([]service.AISessionDisplay, error)
+func (a *App) GetAISession(id string)      (*service.AISessionDetail, error)
+```
+
+`GetTimelineGridData` gains the new map via `TimelineGridData.AIEvents` — no new method needed for the grid itself.
+
+### TimelineGridData extension
+
+```go
+type TimelineGridData struct {
+    // ...existing fields...
+    AIEvents map[int][]AIBlockDisplay `json:"aiEvents"` // hour -> AI blocks
+}
+```
+
+### Categorization
+
+AI activity is reported as its own category `"ai_coding"` in analytics breakdowns, parallel to the existing `Focus` / `Meetings` / `Comms` / `Other` buckets. Implementation: extend whatever existing mechanism populates `DayStats.Breakdown` (currently derived from app categories via `service/appnames.go`) to also surface AI duration under this dedicated key, so AI activity does not distort existing categories. Exact integration point to be determined during plan-writing by reading the current breakdown code.
+
+---
+
+## Frontend
+
+- `frontend/src/api/client.ts` — add `api.ai.list(date)`, `api.ai.get(id)`.
+- `frontend/src/api/hooks.ts` — add `useAISessions(date)`, `useAISession(id)`.
+- `frontend/src/components/timeline/AIEventsLane.tsx` — new lane component modeled on `ShellEventsLane`/`GitEventsLane`. Colors blocks by `projectName`, tool-icon per block (Claude vs opencode), stacks overlapping blocks vertically.
+- Click a block → drawer with session metadata (tool, project, start/end, event count, file path) and a "Reveal in file manager" action for the JSONL path.
+- No new page. Lives inside the existing Timeline grid.
+
+---
+
+## Settings
+
+Extend `internal/service/config.go`:
+
+```go
+type AITrackingConfig struct {
+    Enabled         bool `json:"enabled"`          // default true
+    ClaudeEnabled   bool `json:"claudeEnabled"`    // default true if dir exists
+    OpenCodeEnabled bool `json:"openCodeEnabled"`  // default true if dir exists
+    IdleGapSeconds  int  `json:"idleGapSeconds"`   // default 1800
+}
+```
+
+New settings panel `frontend/src/components/settings/AITrackingSection.tsx`:
+- Master toggle.
+- Per-tool toggles, auto-disabled when the on-disk data dir is not present.
+- Slider for idle gap seconds.
+
+---
+
+## Privacy
+
+- Only timestamps and structural fields are read (`type`, `sessionId`, `cwd`). No message bodies, no tool-call arguments, no diffs.
+- Source files stay in place; we store paths as references, never copies.
+- Deleting Traq's DB purges all AI-derived data.
+- No network I/O anywhere in the AI pipeline.
+
+---
+
+## Testing
+
+- **Unit — plugins.** Fixture JSONLs + fixture opencode SQLite in `internal/tracker/aiplugin/testdata/`. Each plugin's `Poll` is tested against:
+  - empty dir / missing tool → returns no events, no error
+  - single new file → full ingest
+  - subsequent poll with appended lines → only new events returned
+  - corrupt / truncated lines → skipped, error logged, cursor still advances
+- **Integration — AITracker.** Seed a temp `~/.claude/projects/` dir, run two polls, assert rows in `ai_sessions` and `ai_events` and correct `source_offset` after each poll.
+- **Service — block derivation** (`internal/service/ai_test.go`):
+  - empty day
+  - single burst (one block)
+  - idle split at threshold (two blocks, same session_id)
+  - long-mtime-active "don't split" case (one block)
+  - concurrent sessions (two independent block sequences)
+  - hour-boundary split for rendering
+- **No new Playwright e2e in v1.** AI lane renders via the same grid mechanism covered by existing timeline e2e. Add a dedicated e2e in a follow-up.
+
+---
+
+## Open questions / deferred decisions
+
+- Whether to feed `user_prompt` events into activity detection as a presence signal (currently excluded; window focus is considered sufficient).
+- Whether to bridge `tool_use_start` → `tool_use_end` spans instead of relying on mtime rescue, once real-world accuracy can be measured.
+- Whether to add a dedicated AI usage / analytics page — depends on whether the timeline lane alone proves sufficient in daily use.
+- Per-project exclude list (e.g., "don't track sessions in `~/sandbox`").

--- a/docs/superpowers/specs/2026-04-23-ai-coding-data-source-design.md
+++ b/docs/superpowers/specs/2026-04-23-ai-coding-data-source-design.md
@@ -10,11 +10,12 @@
 
 1. Show when the user was engaged with Claude Code / opencode on the daily timeline.
 2. Group activity per tool + session + project, with concurrent sessions rendered as stacked blocks.
-3. Keep v1 minimal: no transcript storage, no cost/analytics page, no new AFK inputs.
+3. Keep v1 minimal: **no transcript storage by default**, no cost/analytics page, no new AFK inputs.
 
 ## Non-goals (v1)
 
-- Storing prompt text, assistant responses, tool-call arguments, diffs, token counts, or cost.
+- Storing assistant responses, tool-call arguments, diffs, token counts, or cost.
+- User-prompt text is stored **only when the user opts in** via Settings → Data Sources → AI Coding → "Store prompt text" (default off). When off, the timeline shows user-prompt markers at their timestamps but no text bodies land in the DB. When on, prompt previews become available in the events list; the toggle takes effect on next app restart.
 - Dedicated AI analytics / usage page.
 - Feeding AI events into AFK / focus-time detection.
 - Cross-tool correlation (matching a Claude session to an opencode session in the same repo).
@@ -251,8 +252,10 @@ New settings panel `frontend/src/components/settings/AITrackingSection.tsx`:
 
 ## Privacy
 
-- Only timestamps and structural fields are read (`type`, `sessionId`, `cwd`). No message bodies, no tool-call arguments, no diffs.
-- Source files stay in place; we store paths as references, never copies.
+- **By default**, only timestamps and structural fields are read (`type`, `sessionId`, `cwd`). Tool-call arguments, diffs, and assistant responses are never stored regardless of settings.
+- **User-prompt text** is stored only when the `storePromptContent` setting is explicitly enabled. When off (default), the `ai_events.content` column stays NULL for every row; the `kind="user_prompt"` marker is still written so the timeline can display a prompt icon at the right timestamp, but no text body.
+- When `storePromptContent` is on, prompt text is captured at mode 0600 into the Traq SQLite database. It never leaves the machine, but anyone with read access to `traq.db` can read verbatim prompt history — the Settings UI makes this explicit before the toggle is flipped.
+- Source files stay in place; we store paths as references, never copies. Paths are kept internal to the Go layer and omitted from Wails bindings (`AISessionDetail.FilePath` has `json:"-"`).
 - Deleting Traq's DB purges all AI-derived data.
 - No network I/O anywhere in the AI pipeline.
 

--- a/frontend/e2e/tests/projects.spec.ts
+++ b/frontend/e2e/tests/projects.spec.ts
@@ -55,6 +55,30 @@ test.describe('Projects Page - Project Management Journey', () => {
     // Leave name empty
     await expect(projectsPage.saveButton).toBeDisabled();
   });
+
+  test('should delete a project via the sidebar trash button', async ({ projectsPage, page }) => {
+    const projectName = `Delete Me ${Date.now()}`;
+    await projectsPage.createProject(projectName, 'Will be deleted');
+    await page.waitForTimeout(1000);
+    expect(await projectsPage.isProjectVisible(projectName)).toBeTruthy();
+
+    // Hover the project row in the sidebar to reveal the trash button.
+    const row = page.locator('nav').getByText(projectName, { exact: false }).first();
+    await row.hover();
+    const trashBtn = row.locator('xpath=ancestor::li').getByTitle('Delete project');
+    await trashBtn.click();
+
+    const confirmDialog = page.getByRole('alertdialog');
+    await expect(confirmDialog).toBeVisible();
+    await expect(confirmDialog.getByText(projectName, { exact: false })).toBeVisible();
+    await confirmDialog.getByRole('button', { name: 'Delete' }).click();
+
+    // Dialog must close (regression guard for the missing-try/catch bug where
+    // an error would leave the dialog stuck open with isPending frozen).
+    await expect(confirmDialog).not.toBeVisible({ timeout: 5000 });
+    await page.waitForTimeout(500);
+    expect(await projectsPage.isProjectVisible(projectName)).toBeFalsy();
+  });
 });
 
 test.describe('Projects in Reports - Integration', () => {

--- a/frontend/e2e/tests/shell-integration.spec.ts
+++ b/frontend/e2e/tests/shell-integration.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '../fixtures/test-fixtures';
+
+test.describe('Shell integration', () => {
+  test('install flow flips pill from Not installed to Active', async ({ page }) => {
+    await page.goto('http://localhost:34115/#/settings');
+    await page.getByText('Data Sources').click();
+    await page.getByText('Shell History').click();
+
+    const strip = page.locator('text=Shell integration').locator('..').locator('..');
+    await expect(strip.getByText('Not installed')).toBeVisible();
+
+    await strip.getByRole('button', { name: 'Install plugin' }).click();
+    await expect(strip.getByText('Active')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/e2e/tests/shell-integration.spec.ts
+++ b/frontend/e2e/tests/shell-integration.spec.ts
@@ -1,5 +1,18 @@
 import { test, expect } from '../fixtures/test-fixtures';
 
+// Skip the whole suite in CI where the Wails dev server (port 34115) isn't
+// running. Without the guard this would hard-timeout every run.
+test.beforeAll(async ({ request }) => {
+  try {
+    const res = await request.get('http://localhost:34115/', { timeout: 2000 });
+    if (!res.ok() && res.status() !== 404) {
+      test.skip(true, `Wails dev server at :34115 returned ${res.status()}`);
+    }
+  } catch (err) {
+    test.skip(true, `Wails dev server not reachable at :34115 (${(err as Error).message})`);
+  }
+});
+
 test.describe('Shell integration', () => {
   test('install flow flips pill from Not installed to Active', async ({ page }) => {
     await page.goto('http://localhost:34115/#/settings');

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1226,6 +1226,7 @@ export const shellSetup = {
   status: (shell: string) => App.GetShellSetupStatus(shell),
   install: (shell: string) => App.InstallShellPlugin(shell),
   uninstall: (shell: string) => App.UninstallShellPlugin(shell),
+  dismissOverflow: () => App.DismissShellOverflow(),
 };
 
 /**

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1265,8 +1265,21 @@ export const updates = {
   },
 };
 
+// AI coding activity (Claude Code, opencode) - timestamp-only session data
+const ai = {
+  list: async (date: string) => {
+    await waitForReady();
+    return App.ListAISessions(date);
+  },
+  get: async (id: string) => {
+    await waitForReady();
+    return App.GetAISession(id);
+  },
+};
+
 // Unified API export
 export const api = {
+  ai,
   analytics,
   timeline,
   reports,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1220,6 +1220,15 @@ export const issues = {
 };
 
 /**
+ * Shell Setup API - Shell plugin install/status/uninstall
+ */
+export const shellSetup = {
+  status: (shell: string) => App.GetShellSetupStatus(shell),
+  install: (shell: string) => App.InstallShellPlugin(shell),
+  uninstall: (shell: string) => App.UninstallShellPlugin(shell),
+};
+
+/**
  * Search API
  */
 const search = {
@@ -1278,5 +1287,6 @@ export const api = {
   issues,
   projects,
   search,
+  shellSetup,
   updates,
 };

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -1754,3 +1754,31 @@ export function useSetUpdateEnabled() {
 
 export { useMultiDayTimeline } from '@/hooks/useMultiDayTimeline';
 export type { DayData, MultiDayTimelineState, ScreenshotItem } from '@/hooks/useMultiDayTimeline';
+
+// ============================================================================
+// Shell Setup Hooks
+// ============================================================================
+
+export function useShellSetupStatus(shell: string) {
+  return useQuery({
+    queryKey: ['shellSetup', shell],
+    queryFn: () => api.shellSetup.status(shell),
+    refetchInterval: 5000,
+  });
+}
+
+export function useInstallShellPlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (shell: string) => api.shellSetup.install(shell),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['shellSetup'] }),
+  });
+}
+
+export function useUninstallShellPlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (shell: string) => api.shellSetup.uninstall(shell),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['shellSetup'] }),
+  });
+}

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -1791,3 +1791,22 @@ export function useDismissShellOverflow() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ['shellSetup'] }),
   });
 }
+
+// ============================================================================
+// AI coding sessions (Claude Code, opencode)
+// ============================================================================
+
+export function useAISessions(date: string) {
+  return useQuery({
+    queryKey: ['ai', 'sessions', date],
+    queryFn: () => api.ai.list(date),
+  });
+}
+
+export function useAISession(id: string | null) {
+  return useQuery({
+    queryKey: ['ai', 'session', id],
+    queryFn: () => api.ai.get(id!),
+    enabled: !!id,
+  });
+}

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -1782,3 +1782,11 @@ export function useUninstallShellPlugin() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ['shellSetup'] }),
   });
 }
+
+export function useDismissShellOverflow() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.shellSetup.dismissOverflow(),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['shellSetup'] }),
+  });
+}

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -481,6 +481,7 @@ export function useUpdateConfig() {
     mutationFn: (updates: Partial<Config>) => api.config.updateConfig(updates),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.config.all() });
+      queryClient.invalidateQueries({ queryKey: ['shellSetup'] });
     },
   });
 }

--- a/frontend/src/components/projects/ProjectsSidebar.tsx
+++ b/frontend/src/components/projects/ProjectsSidebar.tsx
@@ -1,10 +1,20 @@
-import { useMemo } from 'react';
-import { Plus, Loader2, CheckSquare, Square, CircleOff } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Plus, Loader2, CheckSquare, Square, CircleOff, Trash2 } from 'lucide-react';
 import { useQueries } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import { useProjects, useUnassignedEventCount } from '@/api/hooks';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useProjects, useUnassignedEventCount, useDeleteProject } from '@/api/hooks';
 import { api } from '@/api/client';
 
 // Special ID for unassigned activities
@@ -25,6 +35,19 @@ export function ProjectsSidebar({
 }: ProjectsSidebarProps) {
   const { data: projects, isLoading } = useProjects();
   const { data: unassignedCount } = useUnassignedEventCount();
+  const deleteProject = useDeleteProject();
+  const [projectToDelete, setProjectToDelete] = useState<{ id: number; name: string } | null>(null);
+
+  const handleConfirmDelete = async () => {
+    if (!projectToDelete) return;
+    await deleteProject.mutateAsync(projectToDelete.id);
+    if (selectedProjectIds.has(projectToDelete.id)) {
+      const next = new Set(selectedProjectIds);
+      next.delete(projectToDelete.id);
+      onSelectionChange(next);
+    }
+    setProjectToDelete(null);
+  };
 
   // Fetch stats for all projects
   const statsQueries = useQueries({
@@ -170,7 +193,7 @@ export function ProjectsSidebar({
                     {eventCount != null && eventCount > 0 && (
                       <span
                         className={cn(
-                          'text-[10px] px-1.5 py-0.5 rounded-full font-medium',
+                          'text-[10px] px-1.5 py-0.5 rounded-full font-medium group-hover:hidden',
                           isSelected
                             ? 'bg-primary/20 text-primary'
                             : 'bg-muted text-muted-foreground'
@@ -179,6 +202,16 @@ export function ProjectsSidebar({
                         {eventCount.toLocaleString()}
                       </span>
                     )}
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setProjectToDelete({ id: project.id, name: project.name });
+                      }}
+                      className="hidden group-hover:flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                      title="Delete project"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </button>
                   </div>
                 </li>
               );
@@ -190,6 +223,31 @@ export function ProjectsSidebar({
           </div>
         )}
       </nav>
+
+      <AlertDialog
+        open={projectToDelete !== null}
+        onOpenChange={(open) => !open && setProjectToDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Project</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete &quot;{projectToDelete?.name}&quot;? Learned rules and examples are removed.
+              Events already assigned will revert to unassigned.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              disabled={deleteProject.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleteProject.isPending ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </aside>
   );
 }

--- a/frontend/src/components/projects/ProjectsSidebar.tsx
+++ b/frontend/src/components/projects/ProjectsSidebar.tsx
@@ -40,13 +40,20 @@ export function ProjectsSidebar({
 
   const handleConfirmDelete = async () => {
     if (!projectToDelete) return;
-    await deleteProject.mutateAsync(projectToDelete.id);
-    if (selectedProjectIds.has(projectToDelete.id)) {
-      const next = new Set(selectedProjectIds);
-      next.delete(projectToDelete.id);
-      onSelectionChange(next);
+    // Always close the dialog, even on failure. Without the finally, a
+    // backend error leaves the dialog stuck open with isPending still true
+    // — the hook's onError toast fires but the UI can't recover without
+    // a reload. The toast on useDeleteProject already surfaces the error.
+    try {
+      await deleteProject.mutateAsync(projectToDelete.id);
+      if (selectedProjectIds.has(projectToDelete.id)) {
+        const next = new Set(selectedProjectIds);
+        next.delete(projectToDelete.id);
+        onSelectionChange(next);
+      }
+    } finally {
+      setProjectToDelete(null);
     }
-    setProjectToDelete(null);
   };
 
   // Fetch stats for all projects

--- a/frontend/src/components/settings/ShellIntegrationStrip.tsx
+++ b/frontend/src/components/settings/ShellIntegrationStrip.tsx
@@ -72,6 +72,14 @@ export function ShellIntegrationStrip({ shell }: Props) {
         read commands from your shell's native history file, but without those extra fields and with
         some delay.
       </p>
+      {status.state === 'not_installed' && (
+        <p className="text-xs text-muted-foreground">
+          Heads up: captured commands are briefly written to a local log file (mode 0600, in your
+          Traq data directory) before the secret filter runs at ingest. They never leave your
+          machine, but a command containing a secret could sit on disk for a few seconds before
+          being scrubbed.
+        </p>
+      )}
       {status.message && <p className="text-xs text-muted-foreground">{status.message}</p>}
       {status.state === 'active' && (
         <p className="text-xs text-muted-foreground">

--- a/frontend/src/components/settings/ShellIntegrationStrip.tsx
+++ b/frontend/src/components/settings/ShellIntegrationStrip.tsx
@@ -1,4 +1,4 @@
-import { useShellSetupStatus, useInstallShellPlugin, useUninstallShellPlugin } from '@/api/hooks';
+import { useShellSetupStatus, useInstallShellPlugin, useUninstallShellPlugin, useDismissShellOverflow } from '@/api/hooks';
 import { Button } from '@/components/ui/button';
 
 interface Props {
@@ -16,6 +16,7 @@ export function ShellIntegrationStrip({ shell }: Props) {
   const { data: status, isLoading } = useShellSetupStatus(shell);
   const install = useInstallShellPlugin();
   const uninstall = useUninstallShellPlugin();
+  const dismiss = useDismissShellOverflow();
 
   if (isLoading || !status) return null;
 
@@ -23,6 +24,16 @@ export function ShellIntegrationStrip({ shell }: Props) {
 
   return (
     <div className="rounded-md border bg-muted/30 p-3 space-y-2">
+      {status.overflowed && (
+        <div className="rounded-md border border-yellow-500/40 bg-yellow-500/10 p-2 flex items-center justify-between gap-2">
+          <p className="text-xs text-yellow-800 dark:text-yellow-300">
+            Shell log hit its size limit while Traq was idle. Some commands may have been dropped.
+          </p>
+          <Button size="sm" variant="ghost" onClick={() => dismiss.mutate()} disabled={dismiss.isPending}>
+            Dismiss
+          </Button>
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">Shell integration</span>

--- a/frontend/src/components/settings/ShellIntegrationStrip.tsx
+++ b/frontend/src/components/settings/ShellIntegrationStrip.tsx
@@ -58,11 +58,7 @@ export function ShellIntegrationStrip({ shell }: Props) {
             <Button
               size="sm"
               variant="outline"
-              onClick={() => {
-                if (window.confirm('Remove Traq shell integration?')) {
-                  uninstall.mutate(shell);
-                }
-              }}
+              onClick={() => uninstall.mutate(shell)}
               disabled={uninstall.isPending}
             >
               Uninstall
@@ -70,7 +66,13 @@ export function ShellIntegrationStrip({ shell }: Props) {
           )}
         </div>
       </div>
-      <p className="text-xs text-muted-foreground">{status.message}</p>
+      <p className="text-xs text-muted-foreground">
+        Adds a hook to your shell's startup file that records each command as you run it, along with
+        its exit code, duration, working directory, and tmux context. Without this, Traq can still
+        read commands from your shell's native history file, but without those extra fields and with
+        some delay.
+      </p>
+      {status.message && <p className="text-xs text-muted-foreground">{status.message}</p>}
       {status.state === 'active' && (
         <p className="text-xs text-muted-foreground">
           Open a new terminal or run <code className="rounded bg-muted px-1">source {status.rcPath}</code>{' '}

--- a/frontend/src/components/settings/ShellIntegrationStrip.tsx
+++ b/frontend/src/components/settings/ShellIntegrationStrip.tsx
@@ -1,0 +1,71 @@
+import { useShellSetupStatus, useInstallShellPlugin, useUninstallShellPlugin } from '@/api/hooks';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  shell: string;
+}
+
+const stateLabels: Record<string, { pill: string; className: string }> = {
+  not_installed:      { pill: 'Not installed',       className: 'bg-muted text-muted-foreground' },
+  active:             { pill: 'Active',              className: 'bg-green-500/20 text-green-700 dark:text-green-400' },
+  installed_disabled: { pill: 'Installed (disabled)', className: 'bg-yellow-500/20 text-yellow-700 dark:text-yellow-400' },
+  needs_attention:    { pill: 'Needs attention',     className: 'bg-red-500/20 text-red-700 dark:text-red-400' },
+};
+
+export function ShellIntegrationStrip({ shell }: Props) {
+  const { data: status, isLoading } = useShellSetupStatus(shell);
+  const install = useInstallShellPlugin();
+  const uninstall = useUninstallShellPlugin();
+
+  if (isLoading || !status) return null;
+
+  const label = stateLabels[status.state] ?? stateLabels.not_installed;
+
+  return (
+    <div className="rounded-md border bg-muted/30 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">Shell integration</span>
+          <span className={`rounded-full px-2 py-0.5 text-xs ${label.className}`}>
+            {label.pill}
+          </span>
+        </div>
+        <div className="flex gap-2">
+          {status.state === 'not_installed' && (
+            <Button size="sm" onClick={() => install.mutate(shell)} disabled={install.isPending}>
+              Install plugin
+            </Button>
+          )}
+          {status.state === 'needs_attention' && (
+            <Button size="sm" onClick={() => install.mutate(shell)} disabled={install.isPending}>
+              Reinstall
+            </Button>
+          )}
+          {(status.state === 'active' ||
+            status.state === 'installed_disabled' ||
+            status.state === 'needs_attention') && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                if (window.confirm('Remove Traq shell integration?')) {
+                  uninstall.mutate(shell);
+                }
+              }}
+              disabled={uninstall.isPending}
+            >
+              Uninstall
+            </Button>
+          )}
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground">{status.message}</p>
+      {status.state === 'active' && (
+        <p className="text-xs text-muted-foreground">
+          Open a new terminal or run <code className="rounded bg-muted px-1">source {status.rcPath}</code>{' '}
+          to activate in existing shells.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/sections/DataSourcesSettings.tsx
+++ b/frontend/src/components/settings/sections/DataSourcesSettings.tsx
@@ -379,6 +379,32 @@ export function DataSourcesSettings() {
             }}
           />
         </SettingsRow>
+
+        <SettingsRow
+          label="Store prompt text"
+          description="Off by default. When on, verbatim user prompts are saved locally and shown as previews in the events list. Prompts never leave your machine, but they do land in the Traq SQLite database at 0600 — flip this on only if you want the preview feature and accept plaintext storage. Takes effect on next app restart."
+          vertical
+        >
+          <Switch
+            checked={config.dataSources.aiTracking?.storePromptContent ?? false}
+            onCheckedChange={(storePromptContent) =>
+              updateConfig.mutate({
+                dataSources: {
+                  ...config.dataSources,
+                  aiTracking: {
+                    ...(config.dataSources.aiTracking ?? {
+                      enabled: true,
+                      claudeEnabled: true,
+                      openCodeEnabled: true,
+                      idleGapSeconds: 1800,
+                    }),
+                    storePromptContent,
+                  },
+                },
+              })
+            }
+          />
+        </SettingsRow>
       </CollapsibleCard>
     </div>
   );

--- a/frontend/src/components/settings/sections/DataSourcesSettings.tsx
+++ b/frontend/src/components/settings/sections/DataSourcesSettings.tsx
@@ -13,6 +13,7 @@ import { SettingsRow } from '../SettingsRow';
 import { GitRepositoriesSection } from '../GitRepositoriesSection';
 import { FileWatchDirectoriesSection } from '../FileWatchDirectoriesSection';
 import { FileExtensionFilterSection } from '../FileExtensionFilterSection';
+import { ShellIntegrationStrip } from '../ShellIntegrationStrip';
 
 interface CollapsibleCardProps {
   title: string;
@@ -68,6 +69,13 @@ export function DataSourcesSettings() {
           })
         }
       >
+        <ShellIntegrationStrip
+          shell={
+            config.dataSources.shell.shellType === 'auto' || !config.dataSources.shell.shellType
+              ? 'bash'
+              : config.dataSources.shell.shellType
+          }
+        />
         <SettingsRow label="Shell Type" vertical>
           <Select
             value={config.dataSources.shell.shellType || 'auto'}

--- a/frontend/src/components/settings/sections/DataSourcesSettings.tsx
+++ b/frontend/src/components/settings/sections/DataSourcesSettings.tsx
@@ -287,6 +287,99 @@ export function DataSourcesSettings() {
           />
         </SettingsRow>
       </CollapsibleCard>
+
+      <CollapsibleCard
+        title="AI Coding"
+        enabled={config.dataSources.aiTracking?.enabled ?? false}
+        onToggle={(enabled) =>
+          updateConfig.mutate({
+            dataSources: {
+              ...config.dataSources,
+              aiTracking: {
+                ...(config.dataSources.aiTracking ?? {
+                  enabled: false,
+                  claudeEnabled: true,
+                  openCodeEnabled: true,
+                  idleGapSeconds: 1800,
+                }),
+                enabled,
+              },
+            },
+          })
+        }
+      >
+        <SettingsRow label="Track Claude Code" description="Poll ~/.claude/projects JSONL transcripts">
+          <Switch
+            checked={config.dataSources.aiTracking?.claudeEnabled ?? true}
+            onCheckedChange={(claudeEnabled) =>
+              updateConfig.mutate({
+                dataSources: {
+                  ...config.dataSources,
+                  aiTracking: {
+                    ...(config.dataSources.aiTracking ?? {
+                      enabled: true,
+                      claudeEnabled: true,
+                      openCodeEnabled: true,
+                      idleGapSeconds: 1800,
+                    }),
+                    claudeEnabled,
+                  },
+                },
+              })
+            }
+          />
+        </SettingsRow>
+
+        <SettingsRow label="Track opencode" description="Poll opencode's local SQLite database">
+          <Switch
+            checked={config.dataSources.aiTracking?.openCodeEnabled ?? true}
+            onCheckedChange={(openCodeEnabled) =>
+              updateConfig.mutate({
+                dataSources: {
+                  ...config.dataSources,
+                  aiTracking: {
+                    ...(config.dataSources.aiTracking ?? {
+                      enabled: true,
+                      claudeEnabled: true,
+                      openCodeEnabled: true,
+                      idleGapSeconds: 1800,
+                    }),
+                    openCodeEnabled,
+                  },
+                },
+              })
+            }
+          />
+        </SettingsRow>
+
+        <SettingsRow label="Idle Gap (seconds)" description="Split blocks when events are farther apart" vertical>
+          <Input
+            type="number"
+            min={60}
+            max={7200}
+            step={60}
+            value={config.dataSources.aiTracking?.idleGapSeconds ?? 1800}
+            onChange={(e) => {
+              const parsed = parseInt(e.target.value, 10);
+              if (Number.isNaN(parsed)) return;
+              updateConfig.mutate({
+                dataSources: {
+                  ...config.dataSources,
+                  aiTracking: {
+                    ...(config.dataSources.aiTracking ?? {
+                      enabled: true,
+                      claudeEnabled: true,
+                      openCodeEnabled: true,
+                      idleGapSeconds: 1800,
+                    }),
+                    idleGapSeconds: parsed,
+                  },
+                },
+              });
+            }}
+          />
+        </SettingsRow>
+      </CollapsibleCard>
     </div>
   );
 }

--- a/frontend/src/components/settings/sections/DataSourcesSettings.tsx
+++ b/frontend/src/components/settings/sections/DataSourcesSettings.tsx
@@ -20,9 +20,10 @@ interface CollapsibleCardProps {
   enabled: boolean;
   onToggle: (enabled: boolean) => void;
   children: React.ReactNode;
+  alwaysVisible?: React.ReactNode;
 }
 
-function CollapsibleCard({ title, enabled, onToggle, children }: CollapsibleCardProps) {
+function CollapsibleCard({ title, enabled, onToggle, children, alwaysVisible }: CollapsibleCardProps) {
   return (
     <div className="rounded-lg border bg-card">
       <div className="flex items-center justify-between p-4">
@@ -36,9 +37,14 @@ function CollapsibleCard({ title, enabled, onToggle, children }: CollapsibleCard
         </div>
         <Switch checked={enabled} onCheckedChange={onToggle} />
       </div>
+      {alwaysVisible && (
+        <div className="px-4 pb-4 pt-0 border-t">
+          <div className="pt-4">{alwaysVisible}</div>
+        </div>
+      )}
       {enabled && (
-        <div className="px-4 pb-4 pt-0 border-t space-y-4">
-          <div className="pt-4">
+        <div className={`px-4 pb-4 ${alwaysVisible ? 'pt-0' : 'pt-0 border-t'} space-y-4`}>
+          <div className={alwaysVisible ? '' : 'pt-4'}>
             {children}
           </div>
         </div>
@@ -68,14 +74,16 @@ export function DataSourcesSettings() {
             },
           })
         }
+        alwaysVisible={
+          <ShellIntegrationStrip
+            shell={
+              config.dataSources.shell.shellType === 'auto' || !config.dataSources.shell.shellType
+                ? 'bash'
+                : config.dataSources.shell.shellType
+            }
+          />
+        }
       >
-        <ShellIntegrationStrip
-          shell={
-            config.dataSources.shell.shellType === 'auto' || !config.dataSources.shell.shellType
-              ? 'bash'
-              : config.dataSources.shell.shellType
-          }
-        />
         <SettingsRow label="Shell Type" vertical>
           <Select
             value={config.dataSources.shell.shellType || 'auto'}

--- a/frontend/src/components/timeline/EventList.tsx
+++ b/frontend/src/components/timeline/EventList.tsx
@@ -279,7 +279,9 @@ function gridDataToEvents(data: TimelineGridData | undefined): EventDot[] {
         type: 'session',
         row: 'Sessions',
         label: session.summary || `Session: ${appList}${moreApps}`,
-        duration: session.durationSeconds ?? undefined,
+        duration: session.durationSeconds ?? (session.isOngoing
+          ? Math.max(0, Math.floor(Date.now() / 1000) - session.startTime)
+          : undefined),
         color: '#f59e0b',
         metadata: {
           explanation: session.explanation,

--- a/frontend/src/components/timeline/EventList.tsx
+++ b/frontend/src/components/timeline/EventList.tsx
@@ -241,6 +241,30 @@ function gridDataToEvents(data: TimelineGridData | undefined): EventDot[] {
     });
   }
 
+  // Individual AI user prompts
+  if (data.aiPrompts) {
+    data.aiPrompts.forEach((p, idx) => {
+      events.push({
+        id: `ai-prompt-${p.tool}-${p.sessionId}-${p.timestamp}-${idx}`,
+        originalId: p.timestamp,
+        timestamp: new Date(p.timestamp * 1000),
+        type: 'ai',
+        row: 'AI Coding',
+        label: p.preview || `${p.tool} prompt`,
+        color: '#a78bfa',
+        metadata: {
+          tool: p.tool,
+          sessionId: p.sessionId,
+          projectName: p.projectName,
+          projectDir: p.projectDir,
+          kind: 'prompt',
+          preview: p.preview,
+          content: p.content,
+        },
+      });
+    });
+  }
+
   // Session summaries (AI summaries)
   if (data.sessionSummaries) {
     data.sessionSummaries.forEach((session) => {

--- a/frontend/src/components/timeline/EventList.tsx
+++ b/frontend/src/components/timeline/EventList.tsx
@@ -216,6 +216,30 @@ function gridDataToEvents(data: TimelineGridData | undefined): EventDot[] {
     });
   });
 
+  // AI coding blocks
+  if (data.aiEvents) {
+    Object.values(data.aiEvents).flat().forEach((block) => {
+      events.push({
+        id: `ai-${block.tool}-${block.sessionId}-${block.startTime}`,
+        originalId: block.startTime,
+        timestamp: new Date(block.startTime * 1000),
+        type: 'ai',
+        row: 'AI Coding',
+        label: `${block.tool}: ${block.projectName || block.projectDir} (${block.eventCount} events)`,
+        duration: Math.max(0, block.endTime - block.startTime),
+        color: '#8b5cf6',
+        metadata: {
+          tool: block.tool,
+          sessionId: block.sessionId,
+          projectName: block.projectName,
+          projectDir: block.projectDir,
+          eventCount: block.eventCount,
+          isLive: block.isLive,
+        },
+      });
+    });
+  }
+
   // Session summaries (AI summaries)
   if (data.sessionSummaries) {
     data.sessionSummaries.forEach((session) => {

--- a/frontend/src/components/timeline/EventList.tsx
+++ b/frontend/src/components/timeline/EventList.tsx
@@ -59,6 +59,7 @@ const EVENT_TYPE_ICONS: Record<EventDropType, typeof GitCommit> = {
   screenshot: Camera,
   projects: FolderKanban,
   session: Sparkles,
+  ai: Sparkles,
 };
 
 interface EventListProps {

--- a/frontend/src/components/timeline/EventList.tsx
+++ b/frontend/src/components/timeline/EventList.tsx
@@ -259,7 +259,6 @@ function gridDataToEvents(data: TimelineGridData | undefined): EventDot[] {
           projectDir: p.projectDir,
           kind: 'prompt',
           preview: p.preview,
-          content: p.content,
         },
       });
     });

--- a/frontend/src/components/timeline/FilterControls.tsx
+++ b/frontend/src/components/timeline/FilterControls.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { GitBranch, Terminal, FolderOpen, Globe, Camera, RotateCcw } from 'lucide-react';
+import { GitBranch, Terminal, FolderOpen, Globe, Camera, RotateCcw, Sparkles } from 'lucide-react';
 import {
   Tooltip,
   TooltipContent,
@@ -14,6 +14,7 @@ export interface TimelineFilters {
   showFiles: boolean;
   showBrowser: boolean;
   showScreenshots: boolean;
+  showAI: boolean;
 }
 
 interface FilterControlsProps {
@@ -27,6 +28,7 @@ const FILTER_CONFIG = [
   { key: 'showFiles' as const, icon: FolderOpen, label: 'Files' },
   { key: 'showBrowser' as const, icon: Globe, label: 'Browser' },
   { key: 'showScreenshots' as const, icon: Camera, label: 'Screenshots' },
+  { key: 'showAI' as const, icon: Sparkles, label: 'AI Coding' },
 ];
 
 export const FilterControls: React.FC<FilterControlsProps> = ({ filters, onFiltersChange }) => {
@@ -52,6 +54,7 @@ export const FilterControls: React.FC<FilterControlsProps> = ({ filters, onFilte
                   showFiles: true,
                   showBrowser: true,
                   showScreenshots: true,
+                  showAI: true,
                 })}
               >
                 <RotateCcw className="h-3.5 w-3.5" />

--- a/frontend/src/components/timeline/TimelineTooltip.tsx
+++ b/frontend/src/components/timeline/TimelineTooltip.tsx
@@ -22,6 +22,7 @@ const EVENT_TYPE_ICONS: Record<EventDropType, typeof GitCommit> = {
   screenshot: Camera,
   projects: FolderKanban,
   session: Sparkles,
+  ai: Sparkles,
 };
 
 const EVENT_TYPE_LABELS: Record<EventDropType, string> = {
@@ -34,6 +35,7 @@ const EVENT_TYPE_LABELS: Record<EventDropType, string> = {
   screenshot: 'Screenshot',
   projects: 'Project',
   session: 'Session Summary',
+  ai: 'AI Coding',
 };
 
 function formatTime(date: Date): string {
@@ -146,6 +148,22 @@ export const TimelineTooltip = forwardRef<HTMLDivElement, TimelineTooltipProps>(
         }
         if (meta.windowClass) {
           extraDetails.push({ label: 'Window', value: String(meta.windowClass) });
+        }
+        break;
+      }
+      case 'ai': {
+        const meta = event.metadata as Record<string, unknown>;
+        if (meta.tool) {
+          extraDetails.push({ label: 'Tool', value: String(meta.tool) });
+        }
+        if (meta.projectName || meta.projectDir) {
+          extraDetails.push({ label: 'Project', value: String(meta.projectName || meta.projectDir) });
+        }
+        if (meta.eventCount !== undefined) {
+          extraDetails.push({ label: 'Events', value: String(meta.eventCount) });
+        }
+        if (meta.isLive) {
+          extraDetails.push({ label: 'Status', value: 'Live' });
         }
         break;
       }

--- a/frontend/src/components/timeline/timelineTypes.ts
+++ b/frontend/src/components/timeline/timelineTypes.ts
@@ -1,7 +1,7 @@
 // Timeline Types
 // Based on marmelab/EventDrops pattern but adapted for Traq's data structures
 
-export type EventDropType = 'activity' | 'git' | 'shell' | 'browser' | 'file' | 'afk' | 'screenshot' | 'projects' | 'session';
+export type EventDropType = 'activity' | 'git' | 'shell' | 'browser' | 'file' | 'afk' | 'screenshot' | 'projects' | 'session' | 'ai';
 
 export interface EventDot {
   id: string; // Unique ID: `${type}-${originalId}`
@@ -45,6 +45,7 @@ export const EVENT_TYPE_COLORS: Record<EventDropType, string> = {
   screenshot: '#ec4899', // pink-500
   projects: '#6366f1', // indigo-500
   session: '#f59e0b', // amber-500
+  ai: '#8b5cf6', // violet-500
 };
 
 // Category colors for activities (hex values for D3)

--- a/frontend/src/components/timeline/useMultiDayTimelineData.ts
+++ b/frontend/src/components/timeline/useMultiDayTimelineData.ts
@@ -115,9 +115,9 @@ export function useMultiDayTimelineData({
       const data = dayData.gridData as TimelineGridData | null | undefined;
       if (!data) continue;
 
-      // Process activity blocks (always shown)
+      // Process activity blocks (always shown — they're the base layer)
       // When collapseActivityRows is true, merge all into single "In Focus" row
-      if (filters.showScreenshots) {
+      {
         for (const [, hourApps] of Object.entries(data.hourlyGrid)) {
           for (const [appName, activities] of Object.entries(hourApps)) {
             for (const activity of activities) {
@@ -211,6 +211,36 @@ export function useMultiDayTimelineData({
               endTimeMs: shellDur ? event.timestamp * 1000 + shellDur * 1000 : undefined,
               color: EVENT_TYPE_COLORS.shell,
               metadata: event,
+            };
+            addToRow(rowName, dot);
+          }
+        }
+      }
+
+      // Process AI coding events
+      if (filters.showAI && data.aiEvents) {
+        for (const [, hourBlocks] of Object.entries(data.aiEvents)) {
+          for (const block of hourBlocks) {
+            if (isInFuture(block.startTime)) continue;
+
+            const aiKey = `ai-${block.tool}-${block.sessionId}-${block.startTime}`;
+            if (seenEventIds.has(aiKey)) continue;
+            seenEventIds.add(aiKey);
+
+            const rowName = block.projectName || block.tool || 'AI Coding';
+            const durationSec = Math.max(0, block.endTime - block.startTime);
+            const cappedDur = capDuration(dateStr, block.startTime, durationSec);
+            const dot: EventDot = {
+              id: aiKey,
+              originalId: block.startTime,
+              timestamp: new Date(block.startTime * 1000),
+              type: 'ai',
+              row: rowName,
+              label: `${block.tool}: ${block.projectName || block.projectDir} (${block.eventCount} events)`,
+              duration: cappedDur,
+              endTimeMs: cappedDur ? block.startTime * 1000 + cappedDur * 1000 : undefined,
+              color: EVENT_TYPE_COLORS.ai,
+              metadata: block,
             };
             addToRow(rowName, dot);
           }
@@ -337,7 +367,7 @@ export function useMultiDayTimelineData({
       }
 
       // Process screenshots from this day's data
-      if (dayData.screenshots && dayData.screenshots.length > 0) {
+      if (filters.showScreenshots && dayData.screenshots && dayData.screenshots.length > 0) {
         for (const screenshot of dayData.screenshots) {
           // Skip screenshots in the future (shouldn't happen but defensive)
           if (isInFuture(screenshot.timestamp)) continue;

--- a/frontend/src/components/timeline/useMultiDayTimelineData.ts
+++ b/frontend/src/components/timeline/useMultiDayTimelineData.ts
@@ -227,7 +227,7 @@ export function useMultiDayTimelineData({
             if (seenEventIds.has(aiKey)) continue;
             seenEventIds.add(aiKey);
 
-            const rowName = block.projectName || block.tool || 'AI Coding';
+            const rowName = 'AI Coding';
             const durationSec = Math.max(0, block.endTime - block.startTime);
             const cappedDur = capDuration(dateStr, block.startTime, durationSec);
             const dot: EventDot = {
@@ -457,7 +457,7 @@ export function useMultiDayTimelineData({
         if (bFixed !== -1) return 1;
 
         // Special rows go at the bottom
-        const specialRows = ['Git', 'Shell', 'Browser', 'Files'];
+        const specialRows = ['Git', 'Shell', 'Browser', 'Files', 'AI Coding'];
         const aIsSpecial = specialRows.includes(a.name);
         const bIsSpecial = specialRows.includes(b.name);
 

--- a/frontend/src/components/timeline/useMultiDayTimelineData.ts
+++ b/frontend/src/components/timeline/useMultiDayTimelineData.ts
@@ -398,7 +398,10 @@ export function useMultiDayTimelineData({
           const appList = topApps.slice(0, 3).join(', ');
           const moreApps = topApps.length > 3 ? ` +${topApps.length - 3}` : '';
 
-          const sessionDur = capDuration(dateStr, session.startTime, session.durationSeconds ?? undefined);
+          const rawSessionDur = session.durationSeconds ?? (session.isOngoing && dateStr === todayStr
+            ? Math.max(0, nowTimestamp - session.startTime)
+            : undefined);
+          const sessionDur = capDuration(dateStr, session.startTime, rawSessionDur);
           const dot: EventDot = {
             id: makeEventKey('session', session.id),
             originalId: session.id,

--- a/frontend/src/components/timeline/useTimelineData.test.ts
+++ b/frontend/src/components/timeline/useTimelineData.test.ts
@@ -151,7 +151,7 @@ describe('useTimelineData', () => {
       expect(result.current?.rows.find((r) => r.name === 'VS Code')).toBeDefined();
     });
 
-    it('does not process activities when showScreenshots is false', () => {
+    it('activity rows are shown regardless of showScreenshots filter', () => {
       const activity = createMockActivity();
 
       const { result } = renderHook(() =>
@@ -165,9 +165,8 @@ describe('useTimelineData', () => {
         })
       );
 
-      // Activity should not be added
       const chromeRow = result.current?.rows.find((r) => r.name === 'Chrome');
-      expect(chromeRow).toBeUndefined();
+      expect(chromeRow).toBeDefined();
     });
   });
 

--- a/frontend/src/components/timeline/useTimelineData.test.ts
+++ b/frontend/src/components/timeline/useTimelineData.test.ts
@@ -28,6 +28,7 @@ const createMockGridData = (overrides: Partial<TimelineGridData> = {}): Timeline
   shellEvents: {},
   browserEvents: {},
   fileEvents: {},
+  aiEvents: {},
   ...overrides,
 });
 
@@ -38,7 +39,7 @@ const defaultFilters: TimelineFilters = {
   showShell: true,
   showBrowser: true,
   showFiles: true,
-  showAfk: true,
+  showAI: true,
 };
 
 describe('useTimelineData', () => {

--- a/frontend/src/components/timeline/useTimelineData.ts
+++ b/frontend/src/components/timeline/useTimelineData.ts
@@ -418,7 +418,10 @@ export function useTimelineData({
         const appList = topApps.slice(0, 3).join(', ');
         const moreApps = topApps.length > 3 ? ` +${topApps.length - 3}` : '';
 
-        const sessDur = capDuration(session.startTime, session.durationSeconds);
+        const rawSessDur = session.durationSeconds ?? (session.isOngoing
+          ? Math.max(0, nowTimestamp - session.startTime)
+          : undefined);
+        const sessDur = capDuration(session.startTime, rawSessDur);
         const dot: EventDot = {
           id: makeEventKey('session', session.id),
           originalId: session.id,

--- a/frontend/src/components/timeline/useTimelineData.ts
+++ b/frontend/src/components/timeline/useTimelineData.ts
@@ -111,9 +111,9 @@ export function useTimelineData({
       allEvents.push(eventWithRow);
     };
 
-    // Process activity blocks (always shown)
+    // Process activity blocks (always shown — they're the base layer)
     // When collapseActivityRows is true, merge all into single "In Focus" row
-    if (filters.showScreenshots) {
+    {
       for (const [, hourApps] of Object.entries(data.hourlyGrid)) {
         for (const [appName, activities] of Object.entries(hourApps)) {
           for (const activity of activities) {
@@ -313,7 +313,7 @@ export function useTimelineData({
     }
 
     // Process screenshots (if provided)
-    if (screenshots && screenshots.length > 0) {
+    if (filters.showScreenshots && screenshots && screenshots.length > 0) {
       for (const screenshot of screenshots) {
         const rowName = 'Screenshots';
         const dot: EventDot = {

--- a/frontend/src/components/timeline/useTimelineData.ts
+++ b/frontend/src/components/timeline/useTimelineData.ts
@@ -196,9 +196,7 @@ export function useTimelineData({
     if (filters.showAI && data.aiEvents) {
       for (const [, hourBlocks] of Object.entries(data.aiEvents)) {
         for (const block of hourBlocks) {
-          const rowName = groupBy === 'app'
-            ? (block.projectName || block.tool || 'AI Coding')
-            : 'AI Coding';
+          const rowName = 'AI Coding';
           const durationSec = Math.max(0, block.endTime - block.startTime);
           const cappedDur = capDuration(block.startTime, durationSec);
           const dot: EventDot = {
@@ -478,7 +476,7 @@ export function useTimelineData({
         if (bFixed !== -1) return 1;
 
         // Special rows go at the bottom
-        const specialRows = ['Git', 'Shell', 'Browser', 'Files'];
+        const specialRows = ['Git', 'Shell', 'Browser', 'Files', 'AI Coding'];
         const aIsSpecial = specialRows.includes(a.name);
         const bIsSpecial = specialRows.includes(b.name);
 

--- a/frontend/src/components/timeline/useTimelineData.ts
+++ b/frontend/src/components/timeline/useTimelineData.ts
@@ -192,6 +192,32 @@ export function useTimelineData({
       }
     }
 
+    // Process AI coding events
+    if (filters.showAI && data.aiEvents) {
+      for (const [, hourBlocks] of Object.entries(data.aiEvents)) {
+        for (const block of hourBlocks) {
+          const rowName = groupBy === 'app'
+            ? (block.projectName || block.tool || 'AI Coding')
+            : 'AI Coding';
+          const durationSec = Math.max(0, block.endTime - block.startTime);
+          const cappedDur = capDuration(block.startTime, durationSec);
+          const dot: EventDot = {
+            id: `ai-${block.tool}-${block.sessionId}-${block.startTime}`,
+            originalId: block.startTime,
+            timestamp: new Date(block.startTime * 1000),
+            type: 'ai',
+            row: rowName,
+            label: `${block.tool}: ${block.projectName || block.projectDir} (${block.eventCount} events)`,
+            duration: cappedDur,
+            endTimeMs: cappedDur ? block.startTime * 1000 + cappedDur * 1000 : undefined,
+            color: EVENT_TYPE_COLORS.ai,
+            metadata: block,
+          };
+          addToRow(rowName, dot);
+        }
+      }
+    }
+
     // Process browser events
     if (filters.showBrowser) {
       for (const [, hourEvents] of Object.entries(data.browserEvents)) {

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -112,19 +112,21 @@ export function TimelinePage() {
   });
 
   const [filters, setFilters] = useState<TimelineFilters>(() => {
-    try {
-      const stored = localStorage.getItem(FILTER_STORAGE_KEY);
-      if (stored) return JSON.parse(stored);
-    } catch (e) {
-      console.error('Failed to load filters from localStorage:', e);
-    }
-    return {
+    const defaults: TimelineFilters = {
       showGit: true,
       showShell: true,
       showFiles: true,
       showBrowser: true,
       showScreenshots: true,
+      showAI: true,
     };
+    try {
+      const stored = localStorage.getItem(FILTER_STORAGE_KEY);
+      if (stored) return { ...defaults, ...JSON.parse(stored) };
+    } catch (e) {
+      console.error('Failed to load filters from localStorage:', e);
+    }
+    return defaults;
   });
 
   useEffect(() => {

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -88,6 +88,14 @@ export interface DataSourcesConfig {
   git: GitConfig;
   files: FilesConfig;
   browser: BrowserConfig;
+  aiTracking?: AITrackingConfig;
+}
+
+export interface AITrackingConfig {
+  enabled: boolean;
+  claudeEnabled: boolean;
+  openCodeEnabled: boolean;
+  idleGapSeconds: number;
 }
 
 export interface ShellConfig {

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -96,6 +96,7 @@ export interface AITrackingConfig {
   claudeEnabled: boolean;
   openCodeEnabled: boolean;
   idleGapSeconds: number;
+  storePromptContent?: boolean;
 }
 
 export interface ShellConfig {

--- a/frontend/src/types/timeline.ts
+++ b/frontend/src/types/timeline.ts
@@ -15,6 +15,7 @@ export interface TimelineGridData {
   afkBlocks: Record<number, AFKBlock[]>; // hour -> AFK blocks
   activityStates: ActivityState[]; // unified activity lane states (active/break/afk)
   aiEvents: Record<number, AIBlockDisplay[]>; // hour -> AI coding activity blocks
+  aiPrompts: AIPromptDisplay[]; // individual user prompts across the day
 }
 
 export interface AIBlockDisplay {
@@ -26,6 +27,16 @@ export interface AIBlockDisplay {
   endTime: number; // Unix seconds (padded on backend)
   eventCount: number;
   isLive: boolean;
+}
+
+export interface AIPromptDisplay {
+  tool: string;
+  sessionId: string;
+  projectName: string;
+  projectDir: string;
+  timestamp: number; // Unix seconds
+  preview: string; // truncated prompt text for list display
+  content: string; // full prompt text (may be large)
 }
 
 export interface DayStats {

--- a/frontend/src/types/timeline.ts
+++ b/frontend/src/types/timeline.ts
@@ -35,8 +35,7 @@ export interface AIPromptDisplay {
   projectName: string;
   projectDir: string;
   timestamp: number; // Unix seconds
-  preview: string; // truncated prompt text for list display
-  content: string; // full prompt text (may be large)
+  preview: string; // truncated prompt text — full body is intentionally not exposed in list responses
 }
 
 export interface DayStats {

--- a/frontend/src/types/timeline.ts
+++ b/frontend/src/types/timeline.ts
@@ -14,6 +14,18 @@ export interface TimelineGridData {
   browserEvents: Record<number, BrowserEventDisplay[]>; // hour -> browser visits
   afkBlocks: Record<number, AFKBlock[]>; // hour -> AFK blocks
   activityStates: ActivityState[]; // unified activity lane states (active/break/afk)
+  aiEvents: Record<number, AIBlockDisplay[]>; // hour -> AI coding activity blocks
+}
+
+export interface AIBlockDisplay {
+  tool: string; // "claude" | "opencode"
+  sessionId: string;
+  projectDir: string;
+  projectName: string;
+  startTime: number; // Unix seconds
+  endTime: number; // Unix seconds (padded on backend)
+  eventCount: number;
+  isLive: boolean;
 }
 
 export interface DayStats {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -96,6 +96,8 @@ export function GenerateSummary(arg1:number):Promise<storage.Summary>;
 
 export function GenerateWeeklySummaryMarkdown(arg1:string,arg2:string):Promise<string>;
 
+export function GetAISession(arg1:string):Promise<service.AISessionDetail>;
+
 export function GetActivityTags(arg1:string):Promise<Array<service.TagUsage>>;
 
 export function GetAllApps():Promise<Array<main.AppWithCategory>>;
@@ -261,6 +263,8 @@ export function IgnoreActivities(arg1:string,arg2:Array<number>):Promise<void>;
 export function InstallShellPlugin(arg1:string):Promise<void>;
 
 export function IsReady():Promise<boolean>;
+
+export function ListAISessions(arg1:string):Promise<Array<service.AISessionDisplay>>;
 
 export function ListHierarchicalSummaries(arg1:string,arg2:number):Promise<Array<storage.HierarchicalSummary>>;
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -96,6 +96,8 @@ export function GenerateSummary(arg1:number):Promise<storage.Summary>;
 
 export function GenerateWeeklySummaryMarkdown(arg1:string,arg2:string):Promise<string>;
 
+export function GetAIPromptsForDay(arg1:string):Promise<Array<service.AIPromptDisplay>>;
+
 export function GetAISession(arg1:string):Promise<service.AISessionDetail>;
 
 export function GetActivityTags(arg1:string):Promise<Array<service.TagUsage>>;

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -216,6 +216,8 @@ export function GetSessionsForDate(arg1:string):Promise<Array<service.SessionSum
 
 export function GetShellCommandsForSession(arg1:number):Promise<Array<storage.ShellCommand>>;
 
+export function GetShellSetupStatus(arg1:string):Promise<service.SetupStatus>;
+
 export function GetStorageStats():Promise<service.StorageStats>;
 
 export function GetSummary(arg1:number):Promise<storage.Summary>;
@@ -253,6 +255,8 @@ export function GetWeeklyStats(arg1:string):Promise<service.WeeklyStats>;
 export function GetYearlyStats(arg1:number):Promise<service.YearlyStats>;
 
 export function IgnoreActivities(arg1:string,arg2:Array<number>):Promise<void>;
+
+export function InstallShellPlugin(arg1:string):Promise<void>;
 
 export function IsReady():Promise<boolean>;
 
@@ -323,6 +327,8 @@ export function TestIssueWebhook():Promise<void>;
 export function TriggerUpdate():Promise<void>;
 
 export function UnignoreActivities(arg1:string,arg2:Array<number>):Promise<void>;
+
+export function UninstallShellPlugin(arg1:string):Promise<void>;
 
 export function UnregisterGitRepository(arg1:number):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -74,6 +74,8 @@ export function DeleteTimelineCategoryRule(arg1:string):Promise<void>;
 
 export function DiscoverGitRepositories(arg1:Array<string>,arg2:number):Promise<Array<storage.GitRepository>>;
 
+export function DismissShellOverflow():Promise<void>;
+
 export function DownloadModel(arg1:string):Promise<void>;
 
 export function DownloadServer():Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -422,6 +422,10 @@ export function GetShellCommandsForSession(arg1) {
   return window['go']['main']['App']['GetShellCommandsForSession'](arg1);
 }
 
+export function GetShellSetupStatus(arg1) {
+  return window['go']['main']['App']['GetShellSetupStatus'](arg1);
+}
+
 export function GetStorageStats() {
   return window['go']['main']['App']['GetStorageStats']();
 }
@@ -496,6 +500,10 @@ export function GetYearlyStats(arg1) {
 
 export function IgnoreActivities(arg1, arg2) {
   return window['go']['main']['App']['IgnoreActivities'](arg1, arg2);
+}
+
+export function InstallShellPlugin(arg1) {
+  return window['go']['main']['App']['InstallShellPlugin'](arg1);
 }
 
 export function IsReady() {
@@ -636,6 +644,10 @@ export function TriggerUpdate() {
 
 export function UnignoreActivities(arg1, arg2) {
   return window['go']['main']['App']['UnignoreActivities'](arg1, arg2);
+}
+
+export function UninstallShellPlugin(arg1) {
+  return window['go']['main']['App']['UninstallShellPlugin'](arg1);
 }
 
 export function UnregisterGitRepository(arg1) {

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -138,6 +138,10 @@ export function DiscoverGitRepositories(arg1, arg2) {
   return window['go']['main']['App']['DiscoverGitRepositories'](arg1, arg2);
 }
 
+export function DismissShellOverflow() {
+  return window['go']['main']['App']['DismissShellOverflow']();
+}
+
 export function DownloadModel(arg1) {
   return window['go']['main']['App']['DownloadModel'](arg1);
 }

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -182,6 +182,10 @@ export function GenerateWeeklySummaryMarkdown(arg1, arg2) {
   return window['go']['main']['App']['GenerateWeeklySummaryMarkdown'](arg1, arg2);
 }
 
+export function GetAIPromptsForDay(arg1) {
+  return window['go']['main']['App']['GetAIPromptsForDay'](arg1);
+}
+
 export function GetAISession(arg1) {
   return window['go']['main']['App']['GetAISession'](arg1);
 }

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -182,6 +182,10 @@ export function GenerateWeeklySummaryMarkdown(arg1, arg2) {
   return window['go']['main']['App']['GenerateWeeklySummaryMarkdown'](arg1, arg2);
 }
 
+export function GetAISession(arg1) {
+  return window['go']['main']['App']['GetAISession'](arg1);
+}
+
 export function GetActivityTags(arg1) {
   return window['go']['main']['App']['GetActivityTags'](arg1);
 }
@@ -512,6 +516,10 @@ export function InstallShellPlugin(arg1) {
 
 export function IsReady() {
   return window['go']['main']['App']['IsReady']();
+}
+
+export function ListAISessions(arg1) {
+  return window['go']['main']['App']['ListAISessions'](arg1);
 }
 
 export function ListHierarchicalSummaries(arg1, arg2) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -214,6 +214,32 @@ export namespace service {
 	        this.minSessionMinutes = source["minSessionMinutes"];
 	    }
 	}
+	export class AIBlockDisplay {
+	    tool: string;
+	    sessionId: string;
+	    projectDir: string;
+	    projectName: string;
+	    startTime: number;
+	    endTime: number;
+	    eventCount: number;
+	    isLive: boolean;
+	
+	    static createFrom(source: any = {}) {
+	        return new AIBlockDisplay(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.tool = source["tool"];
+	        this.sessionId = source["sessionId"];
+	        this.projectDir = source["projectDir"];
+	        this.projectName = source["projectName"];
+	        this.startTime = source["startTime"];
+	        this.endTime = source["endTime"];
+	        this.eventCount = source["eventCount"];
+	        this.isLive = source["isLive"];
+	    }
+	}
 	export class AIConfig {
 	    summaryMode: string;
 	    summaryChunkMinutes: number;
@@ -228,6 +254,74 @@ export namespace service {
 	        this.summaryMode = source["summaryMode"];
 	        this.summaryChunkMinutes = source["summaryChunkMinutes"];
 	        this.assignmentMode = source["assignmentMode"];
+	    }
+	}
+	export class AISessionDetail {
+	    id: string;
+	    tool: string;
+	    projectName: string;
+	    projectDir: string;
+	    startedAt: number;
+	    lastEventAt: number;
+	    eventCount: number;
+	    filePath: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new AISessionDetail(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.tool = source["tool"];
+	        this.projectName = source["projectName"];
+	        this.projectDir = source["projectDir"];
+	        this.startedAt = source["startedAt"];
+	        this.lastEventAt = source["lastEventAt"];
+	        this.eventCount = source["eventCount"];
+	        this.filePath = source["filePath"];
+	    }
+	}
+	export class AISessionDisplay {
+	    id: string;
+	    tool: string;
+	    projectName: string;
+	    projectDir: string;
+	    startedAt: number;
+	    lastEventAt: number;
+	    eventCount: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new AISessionDisplay(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.tool = source["tool"];
+	        this.projectName = source["projectName"];
+	        this.projectDir = source["projectDir"];
+	        this.startedAt = source["startedAt"];
+	        this.lastEventAt = source["lastEventAt"];
+	        this.eventCount = source["eventCount"];
+	    }
+	}
+	export class AITrackingConfig {
+	    enabled: boolean;
+	    claudeEnabled: boolean;
+	    openCodeEnabled: boolean;
+	    idleGapSeconds: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new AITrackingConfig(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.enabled = source["enabled"];
+	        this.claudeEnabled = source["claudeEnabled"];
+	        this.openCodeEnabled = source["openCodeEnabled"];
+	        this.idleGapSeconds = source["idleGapSeconds"];
 	    }
 	}
 	export class ActivityBlock {
@@ -794,6 +888,7 @@ export namespace service {
 	    git?: GitConfig;
 	    files?: FilesConfig;
 	    browser?: BrowserConfig;
+	    aiTracking?: AITrackingConfig;
 	
 	    static createFrom(source: any = {}) {
 	        return new DataSourcesConfig(source);
@@ -805,6 +900,7 @@ export namespace service {
 	        this.git = this.convertValues(source["git"], GitConfig);
 	        this.files = this.convertValues(source["files"], FilesConfig);
 	        this.browser = this.convertValues(source["browser"], BrowserConfig);
+	        this.aiTracking = this.convertValues(source["aiTracking"], AITrackingConfig);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -2124,6 +2220,7 @@ export namespace service {
 	    browserEvents: Record<number, Array<BrowserEventDisplay>>;
 	    afkBlocks: Record<number, Array<AFKBlock>>;
 	    activityStates: ActivityState[];
+	    aiEvents: Record<number, Array<AIBlockDisplay>>;
 	
 	    static createFrom(source: any = {}) {
 	        return new TimelineGridData(source);
@@ -2143,6 +2240,7 @@ export namespace service {
 	        this.browserEvents = this.convertValues(source["browserEvents"], Array<BrowserEventDisplay>, true);
 	        this.afkBlocks = this.convertValues(source["afkBlocks"], Array<AFKBlock>, true);
 	        this.activityStates = this.convertValues(source["activityStates"], ActivityState);
+	        this.aiEvents = this.convertValues(source["aiEvents"], Array<AIBlockDisplay>, true);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -256,6 +256,28 @@ export namespace service {
 	        this.assignmentMode = source["assignmentMode"];
 	    }
 	}
+	export class AIPromptDisplay {
+	    tool: string;
+	    sessionId: string;
+	    projectName: string;
+	    projectDir: string;
+	    timestamp: number;
+	    preview: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new AIPromptDisplay(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.tool = source["tool"];
+	        this.sessionId = source["sessionId"];
+	        this.projectName = source["projectName"];
+	        this.projectDir = source["projectDir"];
+	        this.timestamp = source["timestamp"];
+	        this.preview = source["preview"];
+	    }
+	}
 	export class AISessionDetail {
 	    id: string;
 	    tool: string;
@@ -264,11 +286,11 @@ export namespace service {
 	    startedAt: number;
 	    lastEventAt: number;
 	    eventCount: number;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new AISessionDetail(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -310,11 +332,11 @@ export namespace service {
 	    openCodeEnabled: boolean;
 	    idleGapSeconds: number;
 	    storePromptContent: boolean;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new AITrackingConfig(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.enabled = source["enabled"];
@@ -2221,6 +2243,7 @@ export namespace service {
 	    afkBlocks: Record<number, Array<AFKBlock>>;
 	    activityStates: ActivityState[];
 	    aiEvents: Record<number, Array<AIBlockDisplay>>;
+	    aiPrompts: AIPromptDisplay[];
 	
 	    static createFrom(source: any = {}) {
 	        return new TimelineGridData(source);
@@ -2241,6 +2264,7 @@ export namespace service {
 	        this.afkBlocks = this.convertValues(source["afkBlocks"], Array<AFKBlock>, true);
 	        this.activityStates = this.convertValues(source["activityStates"], ActivityState);
 	        this.aiEvents = this.convertValues(source["aiEvents"], Array<AIBlockDisplay>, true);
+	        this.aiPrompts = this.convertValues(source["aiPrompts"], AIPromptDisplay);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -3065,6 +3065,9 @@ export namespace storage {
 	    tmuxContext: sql.NullString;
 	    sessionId: sql.NullInt64;
 	    createdAt: number;
+	    projectId: sql.NullInt64;
+	    projectConfidence: sql.NullFloat64;
+	    projectSource: sql.NullString;
 	
 	    static createFrom(source: any = {}) {
 	        return new ShellCommand(source);
@@ -3083,6 +3086,9 @@ export namespace storage {
 	        this.tmuxContext = this.convertValues(source["tmuxContext"], sql.NullString);
 	        this.sessionId = this.convertValues(source["sessionId"], sql.NullInt64);
 	        this.createdAt = source["createdAt"];
+	        this.projectId = this.convertValues(source["projectId"], sql.NullInt64);
+	        this.projectConfidence = this.convertValues(source["projectConfidence"], sql.NullFloat64);
+	        this.projectSource = this.convertValues(source["projectSource"], sql.NullString);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1973,6 +1973,28 @@ export namespace service {
 	        this.category = source["category"];
 	    }
 	}
+	export class SetupStatus {
+	    shell: string;
+	    state: string;
+	    rcPath: string;
+	    pluginPath: string;
+	    overflowed: boolean;
+	    message: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new SetupStatus(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.shell = source["shell"];
+	        this.state = source["state"];
+	        this.rcPath = source["rcPath"];
+	        this.pluginPath = source["pluginPath"];
+	        this.overflowed = source["overflowed"];
+	        this.message = source["message"];
+	    }
+	}
 	
 	export class ShellEventDisplay {
 	    id: number;
@@ -3040,6 +3062,7 @@ export namespace storage {
 	    exitCode: sql.NullInt64;
 	    durationSeconds: sql.NullFloat64;
 	    hostname: sql.NullString;
+	    tmuxContext: sql.NullString;
 	    sessionId: sql.NullInt64;
 	    createdAt: number;
 	
@@ -3057,6 +3080,7 @@ export namespace storage {
 	        this.exitCode = this.convertValues(source["exitCode"], sql.NullInt64);
 	        this.durationSeconds = this.convertValues(source["durationSeconds"], sql.NullFloat64);
 	        this.hostname = this.convertValues(source["hostname"], sql.NullString);
+	        this.tmuxContext = this.convertValues(source["tmuxContext"], sql.NullString);
 	        this.sessionId = this.convertValues(source["sessionId"], sql.NullInt64);
 	        this.createdAt = source["createdAt"];
 	    }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -264,12 +264,11 @@ export namespace service {
 	    startedAt: number;
 	    lastEventAt: number;
 	    eventCount: number;
-	    filePath: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new AISessionDetail(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -279,7 +278,6 @@ export namespace service {
 	        this.startedAt = source["startedAt"];
 	        this.lastEventAt = source["lastEventAt"];
 	        this.eventCount = source["eventCount"];
-	        this.filePath = source["filePath"];
 	    }
 	}
 	export class AISessionDisplay {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -309,17 +309,19 @@ export namespace service {
 	    claudeEnabled: boolean;
 	    openCodeEnabled: boolean;
 	    idleGapSeconds: number;
-	
+	    storePromptContent: boolean;
+
 	    static createFrom(source: any = {}) {
 	        return new AITrackingConfig(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.enabled = source["enabled"];
 	        this.claudeEnabled = source["claudeEnabled"];
 	        this.openCodeEnabled = source["openCodeEnabled"];
 	        this.idleGapSeconds = source["idleGapSeconds"];
+	        this.storePromptContent = source["storePromptContent"];
 	    }
 	}
 	export class ActivityBlock {

--- a/frontend/wailsjs/runtime/runtime.d.ts
+++ b/frontend/wailsjs/runtime/runtime.d.ts
@@ -247,3 +247,84 @@ export function CanResolveFilePaths(): boolean;
 
 // Resolves file paths for an array of files
 export function ResolveFilePaths(files: File[]): void
+
+// Notification types
+export interface NotificationOptions {
+    id: string;
+    title: string;
+    subtitle?: string; // macOS and Linux only
+    body?: string;
+    categoryId?: string;
+    data?: { [key: string]: any };
+}
+
+export interface NotificationAction {
+    id?: string;
+    title?: string;
+    destructive?: boolean; // macOS-specific
+}
+
+export interface NotificationCategory {
+    id?: string;
+    actions?: NotificationAction[];
+    hasReplyField?: boolean;
+    replyPlaceholder?: string;
+    replyButtonTitle?: string;
+}
+
+// [InitializeNotifications](https://wails.io/docs/reference/runtime/notification#initializenotifications)
+// Initializes the notification service for the application.
+// This must be called before sending any notifications.
+export function InitializeNotifications(): Promise<void>;
+
+// [CleanupNotifications](https://wails.io/docs/reference/runtime/notification#cleanupnotifications)
+// Cleans up notification resources and releases any held connections.
+export function CleanupNotifications(): Promise<void>;
+
+// [IsNotificationAvailable](https://wails.io/docs/reference/runtime/notification#isnotificationavailable)
+// Checks if notifications are available on the current platform.
+export function IsNotificationAvailable(): Promise<boolean>;
+
+// [RequestNotificationAuthorization](https://wails.io/docs/reference/runtime/notification#requestnotificationauthorization)
+// Requests notification authorization from the user (macOS only).
+export function RequestNotificationAuthorization(): Promise<boolean>;
+
+// [CheckNotificationAuthorization](https://wails.io/docs/reference/runtime/notification#checknotificationauthorization)
+// Checks the current notification authorization status (macOS only).
+export function CheckNotificationAuthorization(): Promise<boolean>;
+
+// [SendNotification](https://wails.io/docs/reference/runtime/notification#sendnotification)
+// Sends a basic notification with the given options.
+export function SendNotification(options: NotificationOptions): Promise<void>;
+
+// [SendNotificationWithActions](https://wails.io/docs/reference/runtime/notification#sendnotificationwithactions)
+// Sends a notification with action buttons. Requires a registered category.
+export function SendNotificationWithActions(options: NotificationOptions): Promise<void>;
+
+// [RegisterNotificationCategory](https://wails.io/docs/reference/runtime/notification#registernotificationcategory)
+// Registers a notification category that can be used with SendNotificationWithActions.
+export function RegisterNotificationCategory(category: NotificationCategory): Promise<void>;
+
+// [RemoveNotificationCategory](https://wails.io/docs/reference/runtime/notification#removenotificationcategory)
+// Removes a previously registered notification category.
+export function RemoveNotificationCategory(categoryId: string): Promise<void>;
+
+// [RemoveAllPendingNotifications](https://wails.io/docs/reference/runtime/notification#removeallpendingnotifications)
+// Removes all pending notifications from the notification center.
+export function RemoveAllPendingNotifications(): Promise<void>;
+
+// [RemovePendingNotification](https://wails.io/docs/reference/runtime/notification#removependingnotification)
+// Removes a specific pending notification by its identifier.
+export function RemovePendingNotification(identifier: string): Promise<void>;
+
+// [RemoveAllDeliveredNotifications](https://wails.io/docs/reference/runtime/notification#removealldeliverednotifications)
+// Removes all delivered notifications from the notification center.
+export function RemoveAllDeliveredNotifications(): Promise<void>;
+
+// [RemoveDeliveredNotification](https://wails.io/docs/reference/runtime/notification#removedeliverednotification)
+// Removes a specific delivered notification by its identifier.
+export function RemoveDeliveredNotification(identifier: string): Promise<void>;
+
+// [RemoveNotification](https://wails.io/docs/reference/runtime/notification#removenotification)
+// Removes a notification by its identifier (cross-platform convenience function).
+export function RemoveNotification(identifier: string): Promise<void>;

--- a/frontend/wailsjs/runtime/runtime.js
+++ b/frontend/wailsjs/runtime/runtime.js
@@ -240,3 +240,59 @@ export function CanResolveFilePaths() {
 export function ResolveFilePaths(files) {
     return window.runtime.ResolveFilePaths(files);
 }
+
+export function InitializeNotifications() {
+    return window.runtime.InitializeNotifications();
+}
+
+export function CleanupNotifications() {
+    return window.runtime.CleanupNotifications();
+}
+
+export function IsNotificationAvailable() {
+    return window.runtime.IsNotificationAvailable();
+}
+
+export function RequestNotificationAuthorization() {
+    return window.runtime.RequestNotificationAuthorization();
+}
+
+export function CheckNotificationAuthorization() {
+    return window.runtime.CheckNotificationAuthorization();
+}
+
+export function SendNotification(options) {
+    return window.runtime.SendNotification(options);
+}
+
+export function SendNotificationWithActions(options) {
+    return window.runtime.SendNotificationWithActions(options);
+}
+
+export function RegisterNotificationCategory(category) {
+    return window.runtime.RegisterNotificationCategory(category);
+}
+
+export function RemoveNotificationCategory(categoryId) {
+    return window.runtime.RemoveNotificationCategory(categoryId);
+}
+
+export function RemoveAllPendingNotifications() {
+    return window.runtime.RemoveAllPendingNotifications();
+}
+
+export function RemovePendingNotification(identifier) {
+    return window.runtime.RemovePendingNotification(identifier);
+}
+
+export function RemoveAllDeliveredNotifications() {
+    return window.runtime.RemoveAllDeliveredNotifications();
+}
+
+export function RemoveDeliveredNotification(identifier) {
+    return window.runtime.RemoveDeliveredNotification(identifier);
+}
+
+export function RemoveNotification(identifier) {
+    return window.runtime.RemoveNotification(identifier);
+}

--- a/internal/service/ai.go
+++ b/internal/service/ai.go
@@ -16,8 +16,11 @@ const DefaultAIIdleGapSeconds = 30 * 60
 // have a visible footprint in the timeline.
 const blockTailPadSeconds = 30
 
-// osStat is indirected so tests can substitute it.
-var osStat = os.Stat
+// statFn is the file-stat dependency used by block derivation to detect
+// live (recently-modified) sessions. Defaults to os.Stat; tests can override
+// via AIService.SetStatFn to make "is this session live" deterministic
+// without touching real files.
+type statFn func(string) (os.FileInfo, error)
 
 type AIBlockDisplay struct {
 	Tool        string `json:"tool"`
@@ -56,16 +59,33 @@ type AISessionDisplay struct {
 
 type AISessionDetail struct {
 	AISessionDisplay
-	FilePath string `json:"filePath"`
+	// FilePath holds the absolute path to the tool's session file on disk.
+	// Tagged "-" so it's omitted from the JSON payload the frontend sees —
+	// the renderer has no reason to know a user's home directory, and any
+	// future client-side file-open flow should go through an explicit
+	// binding that resolves the path server-side.
+	FilePath string `json:"-"`
 }
 
 type AIService struct {
 	store          *storage.Store
 	idleGapSeconds int
+	stat           statFn
 }
 
 func NewAIService(store *storage.Store) *AIService {
-	return &AIService{store: store, idleGapSeconds: DefaultAIIdleGapSeconds}
+	return &AIService{
+		store:          store,
+		idleGapSeconds: DefaultAIIdleGapSeconds,
+		stat:           os.Stat,
+	}
+}
+
+// SetStatFn overrides the file-stat function for tests.
+func (s *AIService) SetStatFn(fn statFn) {
+	if fn != nil {
+		s.stat = fn
+	}
 }
 
 func (s *AIService) SetIdleGapSeconds(n int) {
@@ -260,7 +280,7 @@ func (s *AIService) applyLiveFileRescue(blocks []AIBlockDisplay, sessionRows map
 		if !ok || row.FilePath == "" {
 			continue
 		}
-		info, err := osStat(row.FilePath)
+		info, err := s.stat(row.FilePath)
 		if err != nil {
 			continue
 		}

--- a/internal/service/ai.go
+++ b/internal/service/ai.go
@@ -1,0 +1,225 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"traq/internal/storage"
+)
+
+// DefaultAIIdleGapSeconds is the threshold between events before a block splits.
+const DefaultAIIdleGapSeconds = 30 * 60
+
+// blockTailPadSeconds pads the end of every block so single-event blocks
+// have a visible footprint in the timeline.
+const blockTailPadSeconds = 30
+
+// osStat is indirected so tests can substitute it.
+var osStat = os.Stat
+
+type AIBlockDisplay struct {
+	Tool        string `json:"tool"`
+	SessionID   string `json:"sessionId"`
+	ProjectDir  string `json:"projectDir"`
+	ProjectName string `json:"projectName"`
+	StartTime   int64  `json:"startTime"`
+	EndTime     int64  `json:"endTime"`
+	EventCount  int    `json:"eventCount"`
+	IsLive      bool   `json:"isLive"`
+}
+
+type AISessionDisplay struct {
+	ID          string `json:"id"`
+	Tool        string `json:"tool"`
+	ProjectName string `json:"projectName"`
+	ProjectDir  string `json:"projectDir"`
+	StartedAt   int64  `json:"startedAt"`
+	LastEventAt int64  `json:"lastEventAt"`
+	EventCount  int    `json:"eventCount"`
+}
+
+type AISessionDetail struct {
+	AISessionDisplay
+	FilePath string `json:"filePath"`
+}
+
+type AIService struct {
+	store          *storage.Store
+	idleGapSeconds int
+}
+
+func NewAIService(store *storage.Store) *AIService {
+	return &AIService{store: store, idleGapSeconds: DefaultAIIdleGapSeconds}
+}
+
+func (s *AIService) SetIdleGapSeconds(n int) {
+	if n > 0 {
+		s.idleGapSeconds = n
+	}
+}
+
+func (s *AIService) ListAISessions(date string) ([]AISessionDisplay, error) {
+	start, end, err := aiDayRangeUnix(date)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.store.ListAISessionsForDate(start, end)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AISessionDisplay, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, AISessionDisplay{
+			ID:          r.ID,
+			Tool:        r.Tool,
+			ProjectName: filepath.Base(r.ProjectDir),
+			ProjectDir:  r.ProjectDir,
+			StartedAt:   r.StartedAt,
+			LastEventAt: r.LastEventAt,
+			EventCount:  r.EventCount,
+		})
+	}
+	return out, nil
+}
+
+func (s *AIService) GetAISession(id string) (*AISessionDetail, error) {
+	sess, err := s.store.GetAISessionByID(id)
+	if err != nil || sess == nil {
+		return nil, err
+	}
+	return &AISessionDetail{
+		AISessionDisplay: AISessionDisplay{
+			ID:          sess.ID,
+			Tool:        sess.Tool,
+			ProjectName: filepath.Base(sess.ProjectDir),
+			ProjectDir:  sess.ProjectDir,
+			StartedAt:   sess.StartedAt,
+			LastEventAt: sess.LastEventAt,
+			EventCount:  sess.EventCount,
+		},
+		FilePath: sess.FilePath,
+	}, nil
+}
+
+// GetAIActivityForDay returns derived activity blocks grouped by local hour.
+func (s *AIService) GetAIActivityForDay(date string) (map[int][]AIBlockDisplay, error) {
+	start, end, err := aiDayRangeUnix(date)
+	if err != nil {
+		return nil, err
+	}
+	blocks, err := s.deriveBlocks(start, end)
+	if err != nil {
+		return nil, err
+	}
+	out := map[int][]AIBlockDisplay{}
+	for _, b := range blocks {
+		hr := time.Unix(b.StartTime, 0).In(time.Local).Hour()
+		out[hr] = append(out[hr], b)
+	}
+	return out, nil
+}
+
+// deriveBlocks groups events into per-session blocks, splitting on idle gaps
+// larger than idleGapSeconds. Events from GetAIEventsInRange arrive ordered
+// by (tool, session_id, timestamp) so we can walk them in one pass.
+func (s *AIService) deriveBlocks(startUnix, endUnix int64) ([]AIBlockDisplay, error) {
+	events, err := s.store.GetAIEventsInRange(startUnix, endUnix)
+	if err != nil {
+		return nil, err
+	}
+	if len(events) == 0 {
+		return nil, nil
+	}
+
+	sessionRows := map[string]storage.AISession{}
+	blocks := []AIBlockDisplay{}
+
+	var current *AIBlockDisplay
+	var prevSessionKey string
+	var prevTs int64
+
+	flush := func() {
+		if current == nil {
+			return
+		}
+		current.EndTime += blockTailPadSeconds
+		blocks = append(blocks, *current)
+		current = nil
+	}
+
+	for _, e := range events {
+		key := e.Tool + "|" + e.SessionID
+		gap := e.Timestamp - prevTs
+		if current == nil || key != prevSessionKey || gap > int64(s.idleGapSeconds) {
+			flush()
+
+			row, ok := sessionRows[e.SessionID]
+			if !ok {
+				rp, _ := s.store.GetAISessionByID(e.SessionID)
+				if rp != nil {
+					row = *rp
+					sessionRows[e.SessionID] = row
+				}
+			}
+
+			projectDir := e.ProjectDir
+			if projectDir == "" {
+				projectDir = row.ProjectDir
+			}
+
+			current = &AIBlockDisplay{
+				Tool:        e.Tool,
+				SessionID:   e.SessionID,
+				ProjectDir:  projectDir,
+				ProjectName: filepath.Base(projectDir),
+				StartTime:   e.Timestamp,
+				EndTime:     e.Timestamp,
+				EventCount:  0,
+				IsLive:      false,
+			}
+		}
+		current.EndTime = e.Timestamp
+		current.EventCount++
+		prevSessionKey = key
+		prevTs = e.Timestamp
+	}
+	flush()
+
+	s.applyLiveFileRescue(blocks, sessionRows)
+
+	return blocks, nil
+}
+
+func (s *AIService) applyLiveFileRescue(blocks []AIBlockDisplay, sessionRows map[string]storage.AISession) {
+	threshold := time.Duration(s.idleGapSeconds/3) * time.Second
+	now := time.Now()
+	for i, b := range blocks {
+		if b.Tool != "claude" {
+			continue
+		}
+		row, ok := sessionRows[b.SessionID]
+		if !ok || row.FilePath == "" {
+			continue
+		}
+		info, err := osStat(row.FilePath)
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) < threshold {
+			blocks[i].IsLive = true
+		}
+	}
+}
+
+// aiDayRangeUnix parses a YYYY-MM-DD date (local time) and returns [start, end]
+// as unix seconds covering the calendar day.
+func aiDayRangeUnix(date string) (int64, int64, error) {
+	t, err := time.ParseInLocation("2006-01-02", date, time.Local)
+	if err != nil {
+		return 0, 0, err
+	}
+	start := t.Unix()
+	end := t.Add(24*time.Hour - time.Second).Unix()
+	return start, end, nil
+}

--- a/internal/service/ai.go
+++ b/internal/service/ai.go
@@ -33,14 +33,22 @@ type AIBlockDisplay struct {
 	IsLive      bool   `json:"isLive"`
 }
 
+// AIPromptDisplay is the per-prompt entry returned by GetAIPromptsForDay.
+//
+// Only the truncated Preview is exposed. The full untruncated prompt body
+// stays out of every list response: a typical day-view load would otherwise
+// serialize multi-kilobyte (occasionally multi-megabyte) bodies across the
+// Wails bridge unconditionally, and any frontend XSS sink would then have a
+// straight path to verbatim user input. When a UI surface needs the full
+// text (a per-prompt detail dialog, for example), add an explicit
+// per-session binding rather than re-adding the field here.
 type AIPromptDisplay struct {
 	Tool        string `json:"tool"`
 	SessionID   string `json:"sessionId"`
 	ProjectName string `json:"projectName"`
 	ProjectDir  string `json:"projectDir"`
 	Timestamp   int64  `json:"timestamp"`
-	Preview     string `json:"preview"` // truncated prompt text for list display
-	Content     string `json:"content"` // full prompt text (may be large)
+	Preview     string `json:"preview"`
 }
 
 // promptPreviewMaxChars caps the preview length. The full prompt is kept in
@@ -174,7 +182,6 @@ func (s *AIService) GetAIPromptsForDay(date string) ([]AIPromptDisplay, error) {
 			ProjectDir:  projectDir,
 			Timestamp:   e.Timestamp,
 			Preview:     truncatePrompt(e.Content, promptPreviewMaxChars),
-			Content:     e.Content,
 		})
 	}
 	return out, nil

--- a/internal/service/ai.go
+++ b/internal/service/ai.go
@@ -3,6 +3,7 @@ package service
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"traq/internal/storage"
@@ -28,6 +29,20 @@ type AIBlockDisplay struct {
 	EventCount  int    `json:"eventCount"`
 	IsLive      bool   `json:"isLive"`
 }
+
+type AIPromptDisplay struct {
+	Tool        string `json:"tool"`
+	SessionID   string `json:"sessionId"`
+	ProjectName string `json:"projectName"`
+	ProjectDir  string `json:"projectDir"`
+	Timestamp   int64  `json:"timestamp"`
+	Preview     string `json:"preview"` // truncated prompt text for list display
+	Content     string `json:"content"` // full prompt text (may be large)
+}
+
+// promptPreviewMaxChars caps the preview length. The full prompt is kept in
+// Content for detail views; this is just what the events list renders.
+const promptPreviewMaxChars = 160
 
 type AISessionDisplay struct {
 	ID          string `json:"id"`
@@ -100,6 +115,49 @@ func (s *AIService) GetAISession(id string) (*AISessionDetail, error) {
 		},
 		FilePath: sess.FilePath,
 	}, nil
+}
+
+// GetAIPromptsForDay returns one entry per user-initiated event (Claude
+// user_prompt, opencode message) so they can be listed individually in the
+// events panel. Session rows are looked up to populate project info.
+func (s *AIService) GetAIPromptsForDay(date string) ([]AIPromptDisplay, error) {
+	start, end, err := aiDayRangeUnix(date)
+	if err != nil {
+		return nil, err
+	}
+	events, err := s.store.GetAIEventsInRange(start, end)
+	if err != nil {
+		return nil, err
+	}
+	sessionRows := map[string]storage.AISession{}
+	out := make([]AIPromptDisplay, 0, len(events))
+	for _, e := range events {
+		if e.Kind != "user_prompt" {
+			continue
+		}
+		projectDir := e.ProjectDir
+		if projectDir == "" {
+			row, ok := sessionRows[e.SessionID]
+			if !ok {
+				rp, _ := s.store.GetAISessionByID(e.SessionID)
+				if rp != nil {
+					row = *rp
+					sessionRows[e.SessionID] = row
+				}
+			}
+			projectDir = row.ProjectDir
+		}
+		out = append(out, AIPromptDisplay{
+			Tool:        e.Tool,
+			SessionID:   e.SessionID,
+			ProjectName: filepath.Base(projectDir),
+			ProjectDir:  projectDir,
+			Timestamp:   e.Timestamp,
+			Preview:     truncatePrompt(e.Content, promptPreviewMaxChars),
+			Content:     e.Content,
+		})
+	}
+	return out, nil
 }
 
 // GetAIActivityForDay returns derived activity blocks grouped by local hour.
@@ -210,6 +268,23 @@ func (s *AIService) applyLiveFileRescue(blocks []AIBlockDisplay, sessionRows map
 			blocks[i].IsLive = true
 		}
 	}
+}
+
+// truncatePrompt collapses whitespace and trims to max runes, appending an
+// ellipsis when content was dropped. Slash-command and meta prompts already
+// arrive as short single-line strings; pasted context can be multi-kilobyte
+// so collapsing whitespace keeps the preview visually stable.
+func truncatePrompt(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = strings.Join(strings.Fields(s), " ")
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max]) + "…"
 }
 
 // aiDayRangeUnix parses a YYYY-MM-DD date (local time) and returns [start, end]

--- a/internal/service/ai_test.go
+++ b/internal/service/ai_test.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"traq/internal/storage"
+)
+
+func TestListAISessionsForDate(t *testing.T) {
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	if err := store.UpsertAISession(&storage.AISession{
+		ID: "s1", Tool: "claude", ProjectDir: "/a/b",
+		StartedAt: 1700000000, LastEventAt: 1700000100, EventCount: 3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertAIEvents([]storage.AIEvent{
+		{SessionID: "s1", Tool: "claude", Kind: "user_prompt", Timestamp: 1700000000},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000050},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000100},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewAIService(store)
+	// pick a date from the event timestamps in local time
+	date := time.Unix(1700000000, 0).In(time.Local).Format("2006-01-02")
+	got, err := svc.ListAISessions(date)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(got))
+	}
+	if got[0].ProjectName != "b" {
+		t.Errorf("ProjectName=%q want %q", got[0].ProjectName, "b")
+	}
+	if got[0].Tool != "claude" {
+		t.Errorf("Tool=%q", got[0].Tool)
+	}
+}
+
+func TestDeriveAIBlocksSplitsOnIdleGap(t *testing.T) {
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	_ = store.UpsertAISession(&storage.AISession{ID: "s1", Tool: "claude", StartedAt: 0, LastEventAt: 0})
+	events := []storage.AIEvent{
+		{SessionID: "s1", Tool: "claude", Kind: "user_prompt", Timestamp: 1700000000},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000060},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000120},
+		{SessionID: "s1", Tool: "claude", Kind: "user_prompt", Timestamp: 1700004000},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700004060},
+	}
+	_ = store.InsertAIEvents(events)
+
+	svc := NewAIService(store)
+	blocks, err := svc.deriveBlocks(1700000000, 1700100000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks after gap split, got %d", len(blocks))
+	}
+	if blocks[0].EventCount != 3 || blocks[1].EventCount != 2 {
+		t.Errorf("counts: %d, %d", blocks[0].EventCount, blocks[1].EventCount)
+	}
+}
+
+func TestDeriveAIBlocksSplitsPerSession(t *testing.T) {
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	_ = store.UpsertAISession(&storage.AISession{ID: "s1", Tool: "claude", StartedAt: 0, LastEventAt: 0})
+	_ = store.UpsertAISession(&storage.AISession{ID: "s2", Tool: "claude", StartedAt: 0, LastEventAt: 0})
+	_ = store.InsertAIEvents([]storage.AIEvent{
+		{SessionID: "s1", Tool: "claude", Kind: "user_prompt", Timestamp: 1700000000},
+		{SessionID: "s2", Tool: "claude", Kind: "user_prompt", Timestamp: 1700000010},
+		{SessionID: "s1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000020},
+		{SessionID: "s2", Tool: "claude", Kind: "assistant_turn", Timestamp: 1700000030},
+	})
+
+	svc := NewAIService(store)
+	blocks, err := svc.deriveBlocks(0, 1<<62)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 per-session blocks, got %d", len(blocks))
+	}
+}
+
+func TestGetAIActivityForDayBucketsByHour(t *testing.T) {
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	_ = store.UpsertAISession(&storage.AISession{ID: "s1", Tool: "claude", StartedAt: 0, LastEventAt: 0})
+	base, _ := time.ParseInLocation("2006-01-02 15:04", "2026-04-23 09:30", time.Local)
+	ts := []int64{
+		base.Unix(),
+		base.Add(15 * time.Minute).Unix(),
+		base.Add(90 * time.Minute).Unix(), // 11:00, separate block
+	}
+	var events []storage.AIEvent
+	for _, t := range ts {
+		events = append(events, storage.AIEvent{SessionID: "s1", Tool: "claude", Kind: "user_prompt", Timestamp: t})
+	}
+	_ = store.InsertAIEvents(events)
+
+	svc := NewAIService(store)
+	byHour, err := svc.GetAIActivityForDay("2026-04-23")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(byHour[9]) != 1 {
+		t.Errorf("hour 9: expected 1 block, got %d", len(byHour[9]))
+	}
+	if len(byHour[11]) != 1 {
+		t.Errorf("hour 11: expected 1 block, got %d", len(byHour[11]))
+	}
+}

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -357,6 +357,29 @@ func (s *ConfigService) GetConfig() (*Config, error) {
 		}
 	}
 
+	// AI tracking settings — overlay stored values on the defaults from
+	// getDefaultDataSourcesConfig so a missing key keeps the default rather
+	// than zeroing the field.
+	if config.DataSources.AITracking != nil {
+		if val, err := s.store.GetConfig("ai.tracking.enabled"); err == nil && val != "" {
+			config.DataSources.AITracking.Enabled = val == "true"
+		}
+		if val, err := s.store.GetConfig("ai.tracking.claudeEnabled"); err == nil && val != "" {
+			config.DataSources.AITracking.ClaudeEnabled = val == "true"
+		}
+		if val, err := s.store.GetConfig("ai.tracking.openCodeEnabled"); err == nil && val != "" {
+			config.DataSources.AITracking.OpenCodeEnabled = val == "true"
+		}
+		if val, err := s.store.GetConfig("ai.tracking.idleGapSeconds"); err == nil && val != "" {
+			if v, e := strconv.Atoi(val); e == nil {
+				config.DataSources.AITracking.IdleGapSeconds = v
+			}
+		}
+		if val, err := s.store.GetConfig("ai.tracking.storePromptContent"); err == nil && val != "" {
+			config.DataSources.AITracking.StorePromptContent = val == "true"
+		}
+	}
+
 	// Issues settings
 	config.Issues = &IssuesConfig{
 		CrashReportingEnabled: true, // Default: send crash reports to Sentry
@@ -523,6 +546,22 @@ func (s *ConfigService) handleConfigSideEffect(key string, value interface{}) er
 			}
 			s.updateInference(config)
 		}
+	case "ai.tracking.enabled", "ai.tracking.claudeEnabled", "ai.tracking.openCodeEnabled":
+		// Hot-reload the AI tracking enable flags to the running daemon so
+		// the toggle takes effect on the next AITracker.Poll tick rather
+		// than waiting for an app restart. storePromptContent and
+		// idleGapSeconds are intentionally restart-only and excluded here.
+		if s.daemon == nil {
+			return nil
+		}
+		config, err := s.GetConfig()
+		if err != nil {
+			return fmt.Errorf("refresh ai tracking config: %w", err)
+		}
+		if config.DataSources != nil && config.DataSources.AITracking != nil {
+			ai := config.DataSources.AITracking
+			s.daemon.SetAITrackingFlags(ai.Enabled, ai.ClaudeEnabled, ai.OpenCodeEnabled)
+		}
 	case "shell.enabled":
 		if s.shellSetup == nil {
 			return nil
@@ -599,6 +638,12 @@ func mapToStorageKey(frontendKey string) string {
 		"dataSources.browser.browsers":         "browser.browsers",
 		"dataSources.browser.excludedDomains":  "browser.excludedDomains",
 		"dataSources.browser.historyLimitDays": "browser.historyLimitDays",
+
+		"dataSources.aiTracking.enabled":            "ai.tracking.enabled",
+		"dataSources.aiTracking.claudeEnabled":      "ai.tracking.claudeEnabled",
+		"dataSources.aiTracking.openCodeEnabled":    "ai.tracking.openCodeEnabled",
+		"dataSources.aiTracking.idleGapSeconds":     "ai.tracking.idleGapSeconds",
+		"dataSources.aiTracking.storePromptContent": "ai.tracking.storePromptContent",
 
 		// Inference settings
 		"inference.engine":         "inference.engine",

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -162,10 +162,19 @@ type AFKConfig struct {
 
 // DataSourcesConfig contains settings for data sources.
 type DataSourcesConfig struct {
-	Shell   *ShellConfig   `json:"shell"`
-	Git     *GitConfig     `json:"git"`
-	Files   *FilesConfig   `json:"files"`
-	Browser *BrowserConfig `json:"browser"`
+	Shell      *ShellConfig      `json:"shell"`
+	Git        *GitConfig        `json:"git"`
+	Files      *FilesConfig      `json:"files"`
+	Browser    *BrowserConfig    `json:"browser"`
+	AITracking *AITrackingConfig `json:"aiTracking"`
+}
+
+// AITrackingConfig controls the Claude Code / opencode timeline lane.
+type AITrackingConfig struct {
+	Enabled         bool `json:"enabled"`
+	ClaudeEnabled   bool `json:"claudeEnabled"`
+	OpenCodeEnabled bool `json:"openCodeEnabled"`
+	IdleGapSeconds  int  `json:"idleGapSeconds"`
 }
 
 // ShellConfig contains shell history settings.
@@ -839,6 +848,12 @@ func (s *ConfigService) getDefaultDataSourcesConfig() *DataSourcesConfig {
 			Enabled:          true,
 			Browsers:         []string{"chrome", "firefox"},
 			HistoryLimitDays: 7, // Default to 7 days of history
+		},
+		AITracking: &AITrackingConfig{
+			Enabled:         true,
+			ClaudeEnabled:   true,
+			OpenCodeEnabled: true,
+			IdleGapSeconds:  1800,
 		},
 	}
 }

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -171,10 +171,10 @@ type DataSourcesConfig struct {
 
 // AITrackingConfig controls the Claude Code / opencode timeline lane.
 //
-// NOTE: Enabled / ClaudeEnabled / OpenCodeEnabled are not currently read by
-// the tracker — the plugins run unconditionally. Fix is tracked as a
-// follow-up; this PR only wires the new StorePromptContent flag since it
-// gates a privacy-sensitive behavior.
+// Enabled is the master toggle; ClaudeEnabled / OpenCodeEnabled gate the
+// individual plugins. All three are applied between poll ticks via
+// AITracker — flipping a toggle in Settings stops the corresponding
+// plugin's next poll without requiring an app restart.
 type AITrackingConfig struct {
 	Enabled         bool `json:"enabled"`
 	ClaudeEnabled   bool `json:"claudeEnabled"`
@@ -725,6 +725,15 @@ func (s *ConfigService) RestartDaemon() error {
 	}
 	if config.DataSources != nil && config.DataSources.AITracking != nil {
 		daemonConfig.AIStorePromptContent = config.DataSources.AITracking.StorePromptContent
+		daemonConfig.AITrackingEnabled = config.DataSources.AITracking.Enabled
+		daemonConfig.AIClaudeEnabled = config.DataSources.AITracking.ClaudeEnabled
+		daemonConfig.AIOpenCodeEnabled = config.DataSources.AITracking.OpenCodeEnabled
+	} else {
+		// Preserve "always on" behavior when the AI section is absent from
+		// an older config file rather than silently disabling tracking.
+		daemonConfig.AITrackingEnabled = true
+		daemonConfig.AIClaudeEnabled = true
+		daemonConfig.AIOpenCodeEnabled = true
 	}
 	s.daemon.UpdateConfig(daemonConfig)
 

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -18,6 +18,7 @@ type ConfigService struct {
 	store           *storage.Store
 	platform        platform.Platform
 	daemon          *tracker.Daemon
+	shellSetup      *ShellSetupService
 	updateInference func(*Config)
 }
 
@@ -38,6 +39,11 @@ func (s *ConfigService) SetInferenceUpdater(update func(*Config)) {
 // SetDaemon sets the daemon reference (for late initialization).
 func (s *ConfigService) SetDaemon(daemon *tracker.Daemon) {
 	s.daemon = daemon
+}
+
+// SetShellSetup sets the shell setup service (for late initialization).
+func (s *ConfigService) SetShellSetup(svc *ShellSetupService) {
+	s.shellSetup = svc
 }
 
 // SyncAutoStart ensures the system autostart state matches the config.
@@ -681,6 +687,13 @@ func (s *ConfigService) RestartDaemon() error {
 		s.daemon.SetShellType(config.DataSources.Shell.ShellType)
 		s.daemon.SetShellHistoryPath(config.DataSources.Shell.HistoryPath)
 		s.daemon.SetShellExcludePatterns(config.DataSources.Shell.ExcludePatterns)
+		if s.shellSetup != nil {
+			if config.DataSources.Shell.Enabled {
+				_ = s.shellSetup.EnableCapture()
+			} else {
+				_ = s.shellSetup.DisableCapture()
+			}
+		}
 	}
 
 	// Apply file tracking configuration

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -497,6 +497,23 @@ func (s *ConfigService) handleConfigSideEffect(key string, value interface{}) er
 			}
 			s.updateInference(config)
 		}
+	case "shell.enabled":
+		if s.shellSetup == nil {
+			return nil
+		}
+		enabled, ok := value.(bool)
+		if !ok {
+			return nil
+		}
+		if enabled {
+			if err := s.shellSetup.EnableCapture(); err != nil {
+				return fmt.Errorf("enable shell capture: %w", err)
+			}
+		} else {
+			if err := s.shellSetup.DisableCapture(); err != nil {
+				return fmt.Errorf("disable shell capture: %w", err)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -170,11 +170,28 @@ type DataSourcesConfig struct {
 }
 
 // AITrackingConfig controls the Claude Code / opencode timeline lane.
+//
+// NOTE: Enabled / ClaudeEnabled / OpenCodeEnabled are not currently read by
+// the tracker — the plugins run unconditionally. Fix is tracked as a
+// follow-up; this PR only wires the new StorePromptContent flag since it
+// gates a privacy-sensitive behavior.
 type AITrackingConfig struct {
 	Enabled         bool `json:"enabled"`
 	ClaudeEnabled   bool `json:"claudeEnabled"`
 	OpenCodeEnabled bool `json:"openCodeEnabled"`
 	IdleGapSeconds  int  `json:"idleGapSeconds"`
+
+	// StorePromptContent opts into storing verbatim user-prompt text on
+	// ai_events rows. Default is false — the timeline shows user-prompt
+	// markers at their timestamps but the text stays out of the DB. When
+	// true, Claude JSONL prompts and opencode user messages are captured
+	// into ai_events.content, enabling prompt previews in the events list.
+	//
+	// Changes take effect on next app restart. This is intentional: a
+	// privacy-sensitive toggle should have an explicit boundary where the
+	// user knows the behavior changed, rather than silently rolling over
+	// on the next poll.
+	StorePromptContent bool `json:"storePromptContent"`
 }
 
 // ShellConfig contains shell history settings.
@@ -706,6 +723,9 @@ func (s *ConfigService) RestartDaemon() error {
 		MonitorMode:        config.Capture.MonitorMode,
 		MonitorIndex:       config.Capture.MonitorIndex,
 	}
+	if config.DataSources != nil && config.DataSources.AITracking != nil {
+		daemonConfig.AIStorePromptContent = config.DataSources.AITracking.StorePromptContent
+	}
 	s.daemon.UpdateConfig(daemonConfig)
 
 	// Apply shell configuration
@@ -850,10 +870,11 @@ func (s *ConfigService) getDefaultDataSourcesConfig() *DataSourcesConfig {
 			HistoryLimitDays: 7, // Default to 7 days of history
 		},
 		AITracking: &AITrackingConfig{
-			Enabled:         true,
-			ClaudeEnabled:   true,
-			OpenCodeEnabled: true,
-			IdleGapSeconds:  1800,
+			Enabled:            true,
+			ClaudeEnabled:      true,
+			OpenCodeEnabled:    true,
+			IdleGapSeconds:     1800,
+			StorePromptContent: false, // privacy-sensitive; opt-in only
 		},
 	}
 }

--- a/internal/service/config_test.go
+++ b/internal/service/config_test.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"traq/internal/platform"
+	"traq/internal/storage"
+)
+
+// stubPlatform is the minimum Platform implementation needed to construct a
+// ConfigService for persistence-layer tests. Only DataDir is exercised by
+// GetConfig + UpdateConfig; the other methods panic loudly so an unintended
+// dependency on them surfaces as a test failure rather than silent zero
+// values.
+type stubPlatform struct{ dataDir string }
+
+func (s *stubPlatform) DataDir() string                                { return s.dataDir }
+func (s *stubPlatform) ConfigDir() string                              { return s.dataDir }
+func (s *stubPlatform) CacheDir() string                               { return s.dataDir }
+func (s *stubPlatform) GetActiveWindow() (*platform.WindowInfo, error) { panic("not used") }
+func (s *stubPlatform) GetLastInputTime() (time.Time, error)           { panic("not used") }
+func (s *stubPlatform) GetShellHistoryPath() string                    { return "" }
+func (s *stubPlatform) GetShellType() string                           { return "bash" }
+func (s *stubPlatform) GetBrowserHistoryPaths() map[string]string      { return nil }
+func (s *stubPlatform) OpenURL(string) error                           { return nil }
+func (s *stubPlatform) ShowNotification(string, string) error          { return nil }
+func (s *stubPlatform) SetAutoStart(bool) error                        { return nil }
+func (s *stubPlatform) IsAutoStartEnabled() (bool, error)              { return false, nil }
+func (s *stubPlatform) GetSystemTheme() string                         { return "light" }
+
+func newTestConfigService(t *testing.T) *ConfigService {
+	t.Helper()
+	store := storage.NewInMemoryTestStore(t)
+	t.Cleanup(func() { store.Close() })
+	// Daemon is nil — the AI tracking side-effect handler guards on this and
+	// becomes a no-op, which is exactly what we want for a persistence-layer
+	// round-trip test.
+	return NewConfigService(store, &stubPlatform{dataDir: t.TempDir()}, nil)
+}
+
+// TestUpdateConfigPersistsAITracking is the regression for the bug where
+// every aiTracking.* field got silently dropped by UpdateConfig: the keys
+// were missing from mapToStorageKey, so the unknown-key skip swallowed
+// them, and GetConfig had no read path either. Toggles in the Settings UI
+// appeared to "not click" because the round trip returned defaults.
+func TestUpdateConfigPersistsAITracking(t *testing.T) {
+	svc := newTestConfigService(t)
+
+	// Defaults should be present on a fresh service so the UI has something
+	// to render even before any user interaction.
+	cfg, err := svc.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.DataSources == nil || cfg.DataSources.AITracking == nil {
+		t.Fatal("default config missing aiTracking section")
+	}
+	if !cfg.DataSources.AITracking.Enabled {
+		t.Errorf("default aiTracking.enabled = false, want true")
+	}
+
+	// Flip every field to a non-default value and persist.
+	updates := map[string]interface{}{
+		"dataSources": map[string]interface{}{
+			"aiTracking": map[string]interface{}{
+				"enabled":            false,
+				"claudeEnabled":      false,
+				"openCodeEnabled":    false,
+				"idleGapSeconds":     float64(900), // JSON numbers arrive as float64
+				"storePromptContent": true,
+			},
+		},
+	}
+	if err := svc.UpdateConfig(updates); err != nil {
+		t.Fatalf("UpdateConfig: %v", err)
+	}
+
+	got, err := svc.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ai := got.DataSources.AITracking
+	if ai == nil {
+		t.Fatal("aiTracking section dropped after persist")
+	}
+	if ai.Enabled {
+		t.Errorf("Enabled = true after persist false")
+	}
+	if ai.ClaudeEnabled {
+		t.Errorf("ClaudeEnabled = true after persist false")
+	}
+	if ai.OpenCodeEnabled {
+		t.Errorf("OpenCodeEnabled = true after persist false")
+	}
+	if ai.IdleGapSeconds != 900 {
+		t.Errorf("IdleGapSeconds = %d, want 900", ai.IdleGapSeconds)
+	}
+	if !ai.StorePromptContent {
+		t.Errorf("StorePromptContent = false after persist true")
+	}
+}
+
+// TestUpdateConfigPartialAITracking confirms the load path overlays stored
+// values on top of defaults rather than zeroing the rest of the section.
+// The frontend's settings page sends per-toggle deltas; if a partial save
+// reset unspecified fields, flipping one toggle would clobber the others.
+func TestUpdateConfigPartialAITracking(t *testing.T) {
+	svc := newTestConfigService(t)
+
+	updates := map[string]interface{}{
+		"dataSources": map[string]interface{}{
+			"aiTracking": map[string]interface{}{
+				"claudeEnabled": false,
+			},
+		},
+	}
+	if err := svc.UpdateConfig(updates); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := svc.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ai := got.DataSources.AITracking
+	if ai.ClaudeEnabled {
+		t.Errorf("ClaudeEnabled not persisted")
+	}
+	// Other fields must keep their defaults.
+	if !ai.Enabled {
+		t.Errorf("partial save clobbered Enabled (now false, want default true)")
+	}
+	if !ai.OpenCodeEnabled {
+		t.Errorf("partial save clobbered OpenCodeEnabled")
+	}
+	if ai.IdleGapSeconds != 1800 {
+		t.Errorf("partial save clobbered IdleGapSeconds: got %d, want default 1800", ai.IdleGapSeconds)
+	}
+}

--- a/internal/service/project_assignment.go
+++ b/internal/service/project_assignment.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -704,6 +705,22 @@ func (s *ProjectAssignmentService) ExtractEventContext(eventType string, eventID
 		}
 		ctx.GitRepo = repoURL
 		ctx.BranchName = branch
+
+	case "shell":
+		// working_directory is by far the strongest project signal for shell
+		// commands — a cwd of ~/repos/traq almost always maps to the Traq project.
+		// shell_type ("bash"/"zsh"/"fish") is too generic to learn from, so we
+		// skip populating AppName.
+		var cwd sql.NullString
+		err := s.store.DB().QueryRow(
+			`SELECT working_directory FROM shell_commands WHERE id = ?`, eventID,
+		).Scan(&cwd)
+		if err != nil {
+			return nil, err
+		}
+		if cwd.Valid {
+			ctx.FilePath = cwd.String
+		}
 	}
 
 	return ctx, nil

--- a/internal/service/project_assignment_shell_test.go
+++ b/internal/service/project_assignment_shell_test.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"traq/internal/storage"
+)
+
+func setupProjectAssignmentTest(t *testing.T) (*ProjectAssignmentService, *storage.Store, func()) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "traq-test-*")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	store, err := storage.NewStore(filepath.Join(dir, "test.db"))
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatalf("NewStore: %v", err)
+	}
+	svc := NewProjectAssignmentService(store)
+	cleanup := func() {
+		store.Close()
+		os.RemoveAll(dir)
+	}
+	return svc, store, cleanup
+}
+
+func TestExtractEventContext_Shell(t *testing.T) {
+	svc, store, cleanup := setupProjectAssignmentTest(t)
+	defer cleanup()
+
+	id, err := store.SaveShellCommand(&storage.ShellCommand{
+		Timestamp:        time.Now().Unix(),
+		Command:          "go test ./...",
+		ShellType:        "bash",
+		WorkingDirectory: sql.NullString{String: "/home/jl/repos/traq", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("save shell command: %v", err)
+	}
+
+	ctx, err := svc.ExtractEventContext("shell", id)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if ctx == nil {
+		t.Fatal("expected non-nil context")
+	}
+	if ctx.FilePath != "/home/jl/repos/traq" {
+		t.Errorf("FilePath: want /home/jl/repos/traq, got %q", ctx.FilePath)
+	}
+}
+
+// ManualAssign is the end-to-end path the UI uses: it calls SetEventProject,
+// then ExtractEventContext, then learnFromAssignment, then AddAssignmentExample.
+// Before this change, SetEventProject rejected "shell" and the user saw
+// "unknown event type: shell" in a dialog.
+func TestManualAssign_Shell_EndToEnd(t *testing.T) {
+	svc, store, cleanup := setupProjectAssignmentTest(t)
+	defer cleanup()
+
+	project, err := store.CreateProject("traq", "#6366f1", "")
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	id, err := store.SaveShellCommand(&storage.ShellCommand{
+		Timestamp:        time.Now().Unix(),
+		Command:          "wails dev -tags webkit2_41",
+		ShellType:        "bash",
+		WorkingDirectory: sql.NullString{String: "/home/jl/repos/traq", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("save shell command: %v", err)
+	}
+
+	if err := svc.ManualAssign("shell", id, project.ID); err != nil {
+		t.Fatalf("manual assign: %v", err)
+	}
+
+	// The row should now point at the project with source="user".
+	var gotProjectID sql.NullInt64
+	var gotSource sql.NullString
+	if err := store.DB().QueryRow(
+		`SELECT project_id, project_source FROM shell_commands WHERE id = ?`, id,
+	).Scan(&gotProjectID, &gotSource); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if !gotProjectID.Valid || gotProjectID.Int64 != project.ID {
+		t.Errorf("project_id: want %d, got %+v", project.ID, gotProjectID)
+	}
+	if gotSource.String != "user" {
+		t.Errorf("source: want user, got %q", gotSource.String)
+	}
+}

--- a/internal/service/shellsetup.go
+++ b/internal/service/shellsetup.go
@@ -1,0 +1,286 @@
+package service
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"traq/internal/tracker/shellplugin"
+)
+
+const (
+	traqFenceStart = "# >>> traq shell integration >>>"
+	traqFenceEnd   = "# <<< traq shell integration <<<"
+	markerFilename = "enabled"
+)
+
+type SetupState string
+
+const (
+	StateNotInstalled      SetupState = "not_installed"
+	StateActive            SetupState = "active"
+	StateInstalledDisabled SetupState = "installed_disabled"
+	StateNeedsAttention    SetupState = "needs_attention"
+)
+
+type SetupStatus struct {
+	Shell      shellplugin.ShellKind `json:"shell"`
+	State      SetupState            `json:"state"`
+	RcPath     string                `json:"rcPath"`
+	PluginPath string                `json:"pluginPath"`
+	Overflowed bool                  `json:"overflowed"`
+	Message    string                `json:"message"`
+}
+
+type ShellSetupService struct {
+	dataDir string
+}
+
+func NewShellSetupService(dataDir string) *ShellSetupService {
+	return &ShellSetupService{dataDir: dataDir}
+}
+
+func (s *ShellSetupService) shellDir() string { return filepath.Join(s.dataDir, "shell") }
+func (s *ShellSetupService) markerPath() string {
+	return filepath.Join(s.shellDir(), markerFilename)
+}
+func (s *ShellSetupService) overflowPath() string {
+	return filepath.Join(s.shellDir(), "overflowed")
+}
+func (s *ShellSetupService) pluginPath(kind shellplugin.ShellKind) string {
+	return filepath.Join(s.shellDir(), shellplugin.Filename(kind))
+}
+
+func (s *ShellSetupService) rcPathFor(kind shellplugin.ShellKind) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	switch kind {
+	case shellplugin.Bash:
+		return filepath.Join(home, ".bashrc"), nil
+	case shellplugin.Zsh:
+		return filepath.Join(home, ".zshrc"), nil
+	case shellplugin.Fish:
+		return filepath.Join(home, ".config", "fish", "config.fish"), nil
+	case shellplugin.PowerShell:
+		return filepath.Join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1"), nil
+	}
+	return "", errors.New("unsupported shell")
+}
+
+func sourceLine(kind shellplugin.ShellKind, pluginPath string) string {
+	switch kind {
+	case shellplugin.Bash, shellplugin.Zsh:
+		return fmt.Sprintf(`[ -f %q ] && . %q`, pluginPath, pluginPath)
+	case shellplugin.Fish:
+		return fmt.Sprintf(`test -f %q; and source %q`, pluginPath, pluginPath)
+	case shellplugin.PowerShell:
+		return fmt.Sprintf(`if (Test-Path %q) { . %q }`, pluginPath, pluginPath)
+	}
+	return ""
+}
+
+func (s *ShellSetupService) Install(kind shellplugin.ShellKind) error {
+	script, err := shellplugin.Script(kind)
+	if err != nil {
+		return fmt.Errorf("load plugin script: %w", err)
+	}
+	if err := os.MkdirAll(s.shellDir(), 0700); err != nil {
+		return fmt.Errorf("create shell dir: %w", err)
+	}
+	pluginPath := s.pluginPath(kind)
+	if err := os.WriteFile(pluginPath, script, 0600); err != nil {
+		return fmt.Errorf("write plugin: %w", err)
+	}
+
+	rcPath, err := s.rcPathFor(kind)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(rcPath), 0755); err != nil {
+		return fmt.Errorf("create rc dir: %w", err)
+	}
+
+	block := strings.Join([]string{
+		traqFenceStart,
+		"# Managed by Traq. Do not edit between these fences.",
+		sourceLine(kind, pluginPath),
+		traqFenceEnd,
+	}, "\n")
+
+	if err := upsertFencedBlock(rcPath, block); err != nil {
+		return fmt.Errorf("update rc file: %w", err)
+	}
+	return nil
+}
+
+func (s *ShellSetupService) Uninstall(kind shellplugin.ShellKind) error {
+	rcPath, err := s.rcPathFor(kind)
+	if err != nil {
+		return err
+	}
+	if err := removeFencedBlock(rcPath); err != nil {
+		return fmt.Errorf("update rc file: %w", err)
+	}
+	if err := os.Remove(s.pluginPath(kind)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove plugin: %w", err)
+	}
+	return nil
+}
+
+func (s *ShellSetupService) EnableCapture() error {
+	if err := os.MkdirAll(s.shellDir(), 0700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(s.markerPath(), os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func (s *ShellSetupService) DisableCapture() error {
+	if err := os.Remove(s.markerPath()); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *ShellSetupService) Status(kind shellplugin.ShellKind) (*SetupStatus, error) {
+	rcPath, err := s.rcPathFor(kind)
+	if err != nil {
+		return nil, err
+	}
+	pluginPath := s.pluginPath(kind)
+
+	rcHasFence := false
+	if data, err := os.ReadFile(rcPath); err == nil {
+		rcHasFence = bytes.Contains(data, []byte(traqFenceStart))
+	}
+	pluginExists := fileExists(pluginPath)
+	markerExists := fileExists(s.markerPath())
+	overflow := fileExists(s.overflowPath())
+
+	status := &SetupStatus{
+		Shell: kind, RcPath: rcPath, PluginPath: pluginPath, Overflowed: overflow,
+	}
+	switch {
+	case rcHasFence && pluginExists && markerExists:
+		status.State = StateActive
+		status.Message = "Capturing commands from all shells."
+	case rcHasFence && pluginExists && !markerExists:
+		status.State = StateInstalledDisabled
+		status.Message = "Plugin installed but idle. Enable Shell History to resume."
+	case rcHasFence && !pluginExists:
+		status.State = StateNeedsAttention
+		status.Message = "Plugin file missing. Reinstall."
+	case !rcHasFence:
+		status.State = StateNotInstalled
+		status.Message = "Install the Traq plugin for real-time capture across tmux and multiple terminals."
+	}
+	if overflow && status.State == StateActive {
+		status.State = StateNeedsAttention
+		status.Message = "Shell log hit size limit while Traq was idle. Some commands may be missing."
+	}
+	return status, nil
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// upsertFencedBlock atomically replaces or appends the fenced block in rcPath.
+func upsertFencedBlock(rcPath, block string) error {
+	existing, err := os.ReadFile(rcPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	var out bytes.Buffer
+	if bytes.Contains(existing, []byte(traqFenceStart)) {
+		scanner := bufio.NewScanner(bytes.NewReader(existing))
+		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+		inside := false
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case !inside && strings.TrimSpace(line) == traqFenceStart:
+				inside = true
+				out.WriteString(block)
+				out.WriteByte('\n')
+			case inside && strings.TrimSpace(line) == traqFenceEnd:
+				inside = false
+			case !inside:
+				out.WriteString(line)
+				out.WriteByte('\n')
+			}
+		}
+	} else {
+		out.Write(existing)
+		if len(existing) > 0 && !bytes.HasSuffix(existing, []byte("\n")) {
+			out.WriteByte('\n')
+		}
+		out.WriteString(block)
+		out.WriteByte('\n')
+	}
+
+	return atomicWriteFile(rcPath, out.Bytes(), 0600)
+}
+
+func removeFencedBlock(rcPath string) error {
+	data, err := os.ReadFile(rcPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !bytes.Contains(data, []byte(traqFenceStart)) {
+		return nil
+	}
+	var out bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	inside := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case !inside && strings.TrimSpace(line) == traqFenceStart:
+			inside = true
+		case inside && strings.TrimSpace(line) == traqFenceEnd:
+			inside = false
+		case !inside:
+			out.WriteString(line)
+			out.WriteByte('\n')
+		}
+	}
+	return atomicWriteFile(rcPath, out.Bytes(), 0600)
+}
+
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".traq.*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/service/shellsetup.go
+++ b/internal/service/shellsetup.go
@@ -151,6 +151,14 @@ func (s *ShellSetupService) DisableCapture() error {
 	return nil
 }
 
+// DismissOverflow removes the overflow sentinel file.
+func (s *ShellSetupService) DismissOverflow() error {
+	if err := os.Remove(s.overflowPath()); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 func (s *ShellSetupService) Status(kind shellplugin.ShellKind) (*SetupStatus, error) {
 	rcPath, err := s.rcPathFor(kind)
 	if err != nil {

--- a/internal/service/shellsetup.go
+++ b/internal/service/shellsetup.go
@@ -116,7 +116,12 @@ func (s *ShellSetupService) Install(kind shellplugin.ShellKind) error {
 	if err := upsertFencedBlock(rcPath, block); err != nil {
 		return fmt.Errorf("update rc file: %w", err)
 	}
-	return nil
+
+	// Enable the capture marker so the plugin actually writes to history.log.
+	// Without this, the sourced plugin short-circuits on the marker check and
+	// post-install status is InstalledDisabled instead of Active — zero
+	// commands captured until the user toggles Shell History on by hand.
+	return s.EnableCapture()
 }
 
 func (s *ShellSetupService) Uninstall(kind shellplugin.ShellKind) error {

--- a/internal/service/shellsetup.go
+++ b/internal/service/shellsetup.go
@@ -180,7 +180,7 @@ func (s *ShellSetupService) Status(kind shellplugin.ShellKind) (*SetupStatus, er
 	switch {
 	case rcHasFence && pluginExists && markerExists:
 		status.State = StateActive
-		status.Message = "Capturing commands from all shells."
+		status.Message = ""
 	case rcHasFence && pluginExists && !markerExists:
 		status.State = StateInstalledDisabled
 		status.Message = "Plugin installed but idle. Enable Shell History to resume."

--- a/internal/service/shellsetup_test.go
+++ b/internal/service/shellsetup_test.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"traq/internal/tracker/shellplugin"
+)
+
+func newShellSetupTest(t *testing.T) (*ShellSetupService, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	dataDir := filepath.Join(home, ".local", "share", "traq")
+	svc := NewShellSetupService(dataDir)
+	return svc, home
+}
+
+func TestInstall_CreatesPluginAndFencesRcFile(t *testing.T) {
+	svc, home := newShellSetupTest(t)
+
+	if err := svc.Install(shellplugin.Bash); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	pluginPath := filepath.Join(home, ".local", "share", "traq", "shell", "plugin.bash")
+	if _, err := os.Stat(pluginPath); err != nil {
+		t.Errorf("plugin file missing: %v", err)
+	}
+
+	rc, err := os.ReadFile(filepath.Join(home, ".bashrc"))
+	if err != nil {
+		t.Fatalf("read .bashrc: %v", err)
+	}
+	s := string(rc)
+	if !strings.Contains(s, traqFenceStart) || !strings.Contains(s, traqFenceEnd) {
+		t.Errorf(".bashrc missing fence: %q", s)
+	}
+	if !strings.Contains(s, "plugin.bash") {
+		t.Errorf(".bashrc missing plugin ref: %q", s)
+	}
+}
+
+func TestInstall_Idempotent(t *testing.T) {
+	svc, home := newShellSetupTest(t)
+	if err := svc.Install(shellplugin.Bash); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if err := svc.Install(shellplugin.Bash); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	rc, _ := os.ReadFile(filepath.Join(home, ".bashrc"))
+	count := strings.Count(string(rc), traqFenceStart)
+	if count != 1 {
+		t.Errorf("fence start appears %d times, want 1: %s", count, rc)
+	}
+}
+
+func TestUninstall_RestoresRcFile(t *testing.T) {
+	svc, home := newShellSetupTest(t)
+	rcPath := filepath.Join(home, ".bashrc")
+	original := "# user content above\nexport PATH=$PATH:/foo\n"
+	if err := os.WriteFile(rcPath, []byte(original), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.Install(shellplugin.Bash); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := svc.Uninstall(shellplugin.Bash); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	got, _ := os.ReadFile(rcPath)
+	if string(got) != original {
+		t.Errorf("rc file not restored\nwant: %q\ngot:  %q", original, got)
+	}
+	pluginPath := filepath.Join(home, ".local", "share", "traq", "shell", "plugin.bash")
+	if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
+		t.Errorf("plugin file not deleted")
+	}
+}
+
+func TestStatus_Transitions(t *testing.T) {
+	svc, _ := newShellSetupTest(t)
+
+	st, err := svc.Status(shellplugin.Bash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != StateNotInstalled {
+		t.Errorf("expected NotInstalled, got %s", st.State)
+	}
+
+	if err := svc.Install(shellplugin.Bash); err != nil {
+		t.Fatal(err)
+	}
+	svc.EnableCapture()
+	st, _ = svc.Status(shellplugin.Bash)
+	if st.State != StateActive {
+		t.Errorf("expected Active, got %s", st.State)
+	}
+
+	svc.DisableCapture()
+	st, _ = svc.Status(shellplugin.Bash)
+	if st.State != StateInstalledDisabled {
+		t.Errorf("expected InstalledDisabled, got %s", st.State)
+	}
+}
+
+func TestMarkerTiesToConfigToggle(t *testing.T) {
+	svc, home := newShellSetupTest(t)
+	if err := svc.EnableCapture(); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(home, ".local", "share", "traq", "shell", "enabled")
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("marker missing after EnableCapture: %v", err)
+	}
+	if err := svc.DisableCapture(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Errorf("marker still present after DisableCapture")
+	}
+}

--- a/internal/service/shellsetup_test.go
+++ b/internal/service/shellsetup_test.go
@@ -98,10 +98,11 @@ func TestStatus_Transitions(t *testing.T) {
 	if err := svc.Install(shellplugin.Bash); err != nil {
 		t.Fatal(err)
 	}
-	svc.EnableCapture()
+	// Install enables capture automatically; state should be Active without
+	// a separate EnableCapture call.
 	st, _ = svc.Status(shellplugin.Bash)
 	if st.State != StateActive {
-		t.Errorf("expected Active, got %s", st.State)
+		t.Errorf("expected Active after Install, got %s", st.State)
 	}
 
 	svc.DisableCapture()

--- a/internal/service/timeline_grid.go
+++ b/internal/service/timeline_grid.go
@@ -23,6 +23,7 @@ type TimelineGridData struct {
 	AFKBlocks        map[int][]AFKBlock                        `json:"afkBlocks"` // hour -> AFK blocks
 	ActivityStates   []ActivityState                           `json:"activityStates"` // unified activity lane states
 	AIEvents         map[int][]AIBlockDisplay                  `json:"aiEvents"` // hour -> AI coding activity blocks
+	AIPrompts        []AIPromptDisplay                         `json:"aiPrompts"` // individual user prompts
 }
 
 // DayStats contains aggregated statistics for a day.
@@ -973,9 +974,14 @@ func (s *TimelineService) GetTimelineGridDataWithOptions(date string, opts Timel
 
 	// AI coding activity (Claude Code, opencode). Swallow errors to match the
 	// treatment of other optional lanes — absence shouldn't break the grid.
-	aiEvents, _ := NewAIService(s.store).GetAIActivityForDay(date)
+	aiSvc := NewAIService(s.store)
+	aiEvents, _ := aiSvc.GetAIActivityForDay(date)
 	if aiEvents == nil {
 		aiEvents = map[int][]AIBlockDisplay{}
+	}
+	aiPrompts, _ := aiSvc.GetAIPromptsForDay(date)
+	if aiPrompts == nil {
+		aiPrompts = []AIPromptDisplay{}
 	}
 
 	return &TimelineGridData{
@@ -992,6 +998,7 @@ func (s *TimelineService) GetTimelineGridDataWithOptions(date string, opts Timel
 		AFKBlocks:        afkBlocks,
 		ActivityStates:   activityStates,
 		AIEvents:         aiEvents,
+		AIPrompts:        aiPrompts,
 	}, nil
 }
 

--- a/internal/service/timeline_grid.go
+++ b/internal/service/timeline_grid.go
@@ -22,6 +22,7 @@ type TimelineGridData struct {
 	BrowserEvents    map[int][]BrowserEventDisplay             `json:"browserEvents"` // hour -> browser visits
 	AFKBlocks        map[int][]AFKBlock                        `json:"afkBlocks"` // hour -> AFK blocks
 	ActivityStates   []ActivityState                           `json:"activityStates"` // unified activity lane states
+	AIEvents         map[int][]AIBlockDisplay                  `json:"aiEvents"` // hour -> AI coding activity blocks
 }
 
 // DayStats contains aggregated statistics for a day.
@@ -970,6 +971,13 @@ func (s *TimelineService) GetTimelineGridDataWithOptions(date string, opts Timel
 	// Calculate activity states for the unified Activity lane
 	activityStates := s.calculateActivityStates(focusEvents, flattenAFKBlocks(afkBlocks), dayStart.Unix(), dayEnd.Unix())
 
+	// AI coding activity (Claude Code, opencode). Swallow errors to match the
+	// treatment of other optional lanes — absence shouldn't break the grid.
+	aiEvents, _ := NewAIService(s.store).GetAIActivityForDay(date)
+	if aiEvents == nil {
+		aiEvents = map[int][]AIBlockDisplay{}
+	}
+
 	return &TimelineGridData{
 		Date:             date,
 		DayStats:         dayStats,
@@ -983,6 +991,7 @@ func (s *TimelineService) GetTimelineGridDataWithOptions(date string, opts Timel
 		BrowserEvents:    browserEvents,
 		AFKBlocks:        afkBlocks,
 		ActivityStates:   activityStates,
+		AIEvents:         aiEvents,
 	}, nil
 }
 

--- a/internal/storage/ai.go
+++ b/internal/storage/ai.go
@@ -25,6 +25,7 @@ type AIEvent struct {
 	Kind       string
 	Timestamp  int64
 	ProjectDir string
+	Content    string // empty unless this is a user prompt
 }
 
 func (s *Store) UpsertAISession(sess *AISession) error {
@@ -85,8 +86,8 @@ func (s *Store) InsertAIEvents(events []AIEvent) error {
 		return err
 	}
 	stmt, err := tx.Prepare(`
-		INSERT INTO ai_events (session_id, tool, kind, timestamp, project_dir)
-		VALUES (?, ?, ?, ?, ?)
+		INSERT INTO ai_events (session_id, tool, kind, timestamp, project_dir, content)
+		VALUES (?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		tx.Rollback()
@@ -94,7 +95,7 @@ func (s *Store) InsertAIEvents(events []AIEvent) error {
 	}
 	defer stmt.Close()
 	for _, e := range events {
-		if _, err := stmt.Exec(e.SessionID, e.Tool, e.Kind, e.Timestamp, aiNullableStr(e.ProjectDir)); err != nil {
+		if _, err := stmt.Exec(e.SessionID, e.Tool, e.Kind, e.Timestamp, aiNullableStr(e.ProjectDir), aiNullableStr(e.Content)); err != nil {
 			tx.Rollback()
 			return err
 		}
@@ -104,7 +105,7 @@ func (s *Store) InsertAIEvents(events []AIEvent) error {
 
 func (s *Store) GetAIEventsInRange(startUnix, endUnix int64) ([]AIEvent, error) {
 	rows, err := s.db.Query(`
-		SELECT id, session_id, tool, kind, timestamp, COALESCE(project_dir,'')
+		SELECT id, session_id, tool, kind, timestamp, COALESCE(project_dir,''), COALESCE(content,'')
 		FROM ai_events
 		WHERE timestamp BETWEEN ? AND ?
 		ORDER BY tool, session_id, timestamp
@@ -116,7 +117,7 @@ func (s *Store) GetAIEventsInRange(startUnix, endUnix int64) ([]AIEvent, error) 
 	var out []AIEvent
 	for rows.Next() {
 		var e AIEvent
-		if err := rows.Scan(&e.ID, &e.SessionID, &e.Tool, &e.Kind, &e.Timestamp, &e.ProjectDir); err != nil {
+		if err := rows.Scan(&e.ID, &e.SessionID, &e.Tool, &e.Kind, &e.Timestamp, &e.ProjectDir, &e.Content); err != nil {
 			return nil, err
 		}
 		out = append(out, e)

--- a/internal/storage/ai.go
+++ b/internal/storage/ai.go
@@ -1,0 +1,169 @@
+package storage
+
+import "database/sql"
+
+// AISession represents one AI coding session (Claude Code or opencode).
+// SourceOffset is tool-specific cursor state: byte offset into the JSONL file
+// for claude, unused (0) for opencode which cursors on MAX(timestamp).
+type AISession struct {
+	ID           string
+	Tool         string
+	ProjectDir   string
+	FilePath     string
+	StartedAt    int64
+	LastEventAt  int64
+	EventCount   int
+	SourceOffset int64
+}
+
+// AIEvent is one atomic turn within an AI session (user prompt, assistant
+// turn, tool use, or generic "message"). Timestamp is unix seconds.
+type AIEvent struct {
+	ID         int64
+	SessionID  string
+	Tool       string
+	Kind       string
+	Timestamp  int64
+	ProjectDir string
+}
+
+func (s *Store) UpsertAISession(sess *AISession) error {
+	_, err := s.db.Exec(`
+		INSERT INTO ai_sessions (id, tool, project_dir, file_path, started_at, last_event_at, event_count, source_offset)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			project_dir   = excluded.project_dir,
+			file_path     = excluded.file_path,
+			last_event_at = excluded.last_event_at,
+			event_count   = excluded.event_count,
+			source_offset = excluded.source_offset
+	`, sess.ID, sess.Tool, aiNullableStr(sess.ProjectDir), aiNullableStr(sess.FilePath),
+		sess.StartedAt, sess.LastEventAt, sess.EventCount, sess.SourceOffset)
+	return err
+}
+
+func (s *Store) GetAISessionByFilePath(path string) (*AISession, error) {
+	if path == "" {
+		return nil, nil
+	}
+	row := s.db.QueryRow(`
+		SELECT id, tool, COALESCE(project_dir,''), COALESCE(file_path,''),
+		       started_at, last_event_at, event_count, source_offset
+		FROM ai_sessions WHERE file_path = ?
+	`, path)
+	return scanAISession(row)
+}
+
+func (s *Store) GetAISessionByID(id string) (*AISession, error) {
+	row := s.db.QueryRow(`
+		SELECT id, tool, COALESCE(project_dir,''), COALESCE(file_path,''),
+		       started_at, last_event_at, event_count, source_offset
+		FROM ai_sessions WHERE id = ?
+	`, id)
+	return scanAISession(row)
+}
+
+func scanAISession(row *sql.Row) (*AISession, error) {
+	var out AISession
+	err := row.Scan(&out.ID, &out.Tool, &out.ProjectDir, &out.FilePath,
+		&out.StartedAt, &out.LastEventAt, &out.EventCount, &out.SourceOffset)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (s *Store) InsertAIEvents(events []AIEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	stmt, err := tx.Prepare(`
+		INSERT INTO ai_events (session_id, tool, kind, timestamp, project_dir)
+		VALUES (?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	defer stmt.Close()
+	for _, e := range events {
+		if _, err := stmt.Exec(e.SessionID, e.Tool, e.Kind, e.Timestamp, aiNullableStr(e.ProjectDir)); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (s *Store) GetAIEventsInRange(startUnix, endUnix int64) ([]AIEvent, error) {
+	rows, err := s.db.Query(`
+		SELECT id, session_id, tool, kind, timestamp, COALESCE(project_dir,'')
+		FROM ai_events
+		WHERE timestamp BETWEEN ? AND ?
+		ORDER BY tool, session_id, timestamp
+	`, startUnix, endUnix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AIEvent
+	for rows.Next() {
+		var e AIEvent
+		if err := rows.Scan(&e.ID, &e.SessionID, &e.Tool, &e.Kind, &e.Timestamp, &e.ProjectDir); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetMaxAIEventTimestamp(tool string) (int64, error) {
+	var maxTs sql.NullInt64
+	err := s.db.QueryRow(`SELECT MAX(timestamp) FROM ai_events WHERE tool = ?`, tool).Scan(&maxTs)
+	if err != nil {
+		return 0, err
+	}
+	if !maxTs.Valid {
+		return 0, nil
+	}
+	return maxTs.Int64, nil
+}
+
+func (s *Store) ListAISessionsForDate(startUnix, endUnix int64) ([]AISession, error) {
+	rows, err := s.db.Query(`
+		SELECT DISTINCT s.id, s.tool, COALESCE(s.project_dir,''), COALESCE(s.file_path,''),
+		       s.started_at, s.last_event_at, s.event_count, s.source_offset
+		FROM ai_sessions s
+		JOIN ai_events e ON e.session_id = s.id
+		WHERE e.timestamp BETWEEN ? AND ?
+		ORDER BY s.last_event_at DESC
+	`, startUnix, endUnix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AISession
+	for rows.Next() {
+		var s AISession
+		if err := rows.Scan(&s.ID, &s.Tool, &s.ProjectDir, &s.FilePath,
+			&s.StartedAt, &s.LastEventAt, &s.EventCount, &s.SourceOffset); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+func aiNullableStr(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/storage/ai_test.go
+++ b/internal/storage/ai_test.go
@@ -1,0 +1,104 @@
+package storage
+
+import (
+	"testing"
+)
+
+func TestMigration15CreatesAITables(t *testing.T) {
+	store := NewInMemoryTestStore(t)
+	defer store.Close()
+
+	var count int
+	err := store.db.QueryRow(`
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type='table' AND name IN ('ai_sessions','ai_events')
+	`).Scan(&count)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 AI tables, got %d", count)
+	}
+}
+
+func TestUpsertAISessionInsertsAndUpdates(t *testing.T) {
+	store := NewInMemoryTestStore(t)
+	defer store.Close()
+
+	s := &AISession{
+		ID:           "sess-1",
+		Tool:         "claude",
+		ProjectDir:   "/home/u/repo",
+		FilePath:     "/home/u/.claude/projects/-home-u-repo/sess-1.jsonl",
+		StartedAt:    1700000000,
+		LastEventAt:  1700000100,
+		EventCount:   5,
+		SourceOffset: 2048,
+	}
+	if err := store.UpsertAISession(s); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	got, err := store.GetAISessionByFilePath(s.FilePath)
+	if err != nil || got == nil {
+		t.Fatalf("get after insert: got=%v err=%v", got, err)
+	}
+	if got.EventCount != 5 || got.SourceOffset != 2048 {
+		t.Fatalf("mismatched fields: %+v", got)
+	}
+
+	s.EventCount = 9
+	s.SourceOffset = 4096
+	s.LastEventAt = 1700000200
+	if err := store.UpsertAISession(s); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	got, _ = store.GetAISessionByFilePath(s.FilePath)
+	if got.EventCount != 9 || got.SourceOffset != 4096 {
+		t.Fatalf("update did not apply: %+v", got)
+	}
+}
+
+func TestInsertAndQueryAIEvents(t *testing.T) {
+	store := NewInMemoryTestStore(t)
+	defer store.Close()
+
+	s := &AISession{ID: "sess-1", Tool: "claude", StartedAt: 1000, LastEventAt: 1000}
+	if err := store.UpsertAISession(s); err != nil {
+		t.Fatal(err)
+	}
+
+	events := []AIEvent{
+		{SessionID: "sess-1", Tool: "claude", Kind: "user_prompt", Timestamp: 1010},
+		{SessionID: "sess-1", Tool: "claude", Kind: "assistant_turn", Timestamp: 1020},
+		{SessionID: "sess-1", Tool: "claude", Kind: "tool_use", Timestamp: 1030},
+	}
+	if err := store.InsertAIEvents(events); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	got, err := store.GetAIEventsInRange(1000, 2000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(got))
+	}
+
+	maxTs, err := store.GetMaxAIEventTimestamp("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if maxTs != 1030 {
+		t.Fatalf("expected max ts 1030, got %d", maxTs)
+	}
+
+	sessions, err := store.ListAISessionsForDate(1000, 2000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+}

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -952,6 +952,12 @@ func (s *Store) applyMigration13() error {
 	return nil
 }
 
+// repairShellCommandsTable re-adds columns and indexes that should exist on
+// shell_commands but may be missing if an earlier dev build stamped
+// schema_version past a migration without running its DDL (partial apply,
+// crash mid-migration, etc.). Covers migration 13 (tmux_context) and
+// migration 14 (project assignment). Each check is independent so a repair
+// can succeed partially and still move the DB forward.
 func (s *Store) repairShellCommandsTable() {
 	var tableCount int
 	err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='shell_commands'`).Scan(&tableCount)
@@ -959,43 +965,68 @@ func (s *Store) repairShellCommandsTable() {
 		return
 	}
 
-	// Migration 13: tmux_context
-	var colCount int
-	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'tmux_context'`).Scan(&colCount)
-	if err == nil && colCount == 0 {
-		if _, err := s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT`); err != nil {
+	repairs := []struct {
+		column string
+		ddl    string
+	}{
+		{"tmux_context", `ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT`},
+		{"project_id", `ALTER TABLE shell_commands ADD COLUMN project_id INTEGER REFERENCES projects(id)`},
+		{"project_confidence", `ALTER TABLE shell_commands ADD COLUMN project_confidence REAL DEFAULT 0.0`},
+		{"project_source", `ALTER TABLE shell_commands ADD COLUMN project_source TEXT DEFAULT 'unassigned'`},
+	}
+	for _, r := range repairs {
+		var colCount int
+		if err := s.db.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = ?`, r.column,
+		).Scan(&colCount); err != nil {
 			// Wails GUI has no attached console; fmt.Printf would vanish. Use
 			// the project logger so this surfaces in dev logs and log files.
-			log.Printf("repairShellCommandsTable: failed to add tmux_context column: %v", err)
+			log.Printf("repairShellCommandsTable: check %s column: %v", r.column, err)
+			continue
+		}
+		if colCount > 0 {
+			continue
+		}
+		if _, err := s.db.Exec(r.ddl); err != nil {
+			log.Printf("repairShellCommandsTable: add %s column: %v", r.column, err)
 		}
 	}
-
-	// Migration 14: project assignment columns
-	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'project_id'`).Scan(&colCount)
-	if err == nil && colCount == 0 {
-		s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_id INTEGER REFERENCES projects(id)`)
+	if _, err := s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_shell_project ON shell_commands(project_id)`); err != nil {
+		log.Printf("repairShellCommandsTable: create idx_shell_project: %v", err)
 	}
-	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'project_confidence'`).Scan(&colCount)
-	if err == nil && colCount == 0 {
-		s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_confidence REAL DEFAULT 0.0`)
-	}
-	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'project_source'`).Scan(&colCount)
-	if err == nil && colCount == 0 {
-		s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_source TEXT DEFAULT 'unassigned'`)
-	}
-	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_shell_project ON shell_commands(project_id)`)
 }
 
 // applyMigration14 adds project assignment columns to shell_commands so shell
 // entries can be attributed to projects like screenshots / focus events / git commits.
+// Each ALTER is guarded via pragma_table_info so real failures (disk full, DB
+// locked, schema corruption) surface as errors instead of being silently
+// dropped. Matches the pattern used by applyMigration13 / applyMigration9.
 func (s *Store) applyMigration14() error {
-	// ALTER TABLE ADD COLUMN is idempotent-friendly via the repair path;
-	// any errors here (e.g. column already exists from a partial apply) are
-	// benign — repairShellCommandsTable also runs and guards on existence.
-	s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_id INTEGER REFERENCES projects(id)`)
-	s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_confidence REAL DEFAULT 0.0`)
-	s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_source TEXT DEFAULT 'unassigned'`)
-	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_shell_project ON shell_commands(project_id)`)
+	columns := []struct {
+		name string
+		ddl  string
+	}{
+		{"project_id", `ALTER TABLE shell_commands ADD COLUMN project_id INTEGER REFERENCES projects(id)`},
+		{"project_confidence", `ALTER TABLE shell_commands ADD COLUMN project_confidence REAL DEFAULT 0.0`},
+		{"project_source", `ALTER TABLE shell_commands ADD COLUMN project_source TEXT DEFAULT 'unassigned'`},
+	}
+	for _, c := range columns {
+		var count int
+		if err := s.db.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = ?`, c.name,
+		).Scan(&count); err != nil {
+			return fmt.Errorf("check %s column: %w", c.name, err)
+		}
+		if count > 0 {
+			continue
+		}
+		if _, err := s.db.Exec(c.ddl); err != nil {
+			return fmt.Errorf("add %s column: %w", c.name, err)
+		}
+	}
+	if _, err := s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_shell_project ON shell_commands(project_id)`); err != nil {
+		return fmt.Errorf("create idx_shell_project: %w", err)
+	}
 	return nil
 }
 

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -5,7 +5,7 @@ import (
 	"log"
 )
 
-const schemaVersion = 14
+const schemaVersion = 15
 
 const schema = `
 -- ============================================================================
@@ -341,6 +341,13 @@ func (s *Store) Migrate() error {
 		// Migration v14: Add project assignment columns to shell_commands
 		if err := s.applyMigration14(); err != nil {
 			return fmt.Errorf("failed to apply migration 14: %w", err)
+		}
+	}
+
+	if currentVersion < 15 {
+		// Migration v15: Add ai_sessions and ai_events tables for AI coding activity
+		if err := s.applyMigration15(); err != nil {
+			return fmt.Errorf("failed to apply migration 15: %w", err)
 		}
 	}
 
@@ -1048,4 +1055,38 @@ func (s *Store) applyMigration12() error {
 	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_focus_draft ON window_focus_events(is_draft)`)
 
 	return nil
+}
+
+// applyMigration15 adds ai_sessions and ai_events tables for AI coding
+// session activity (Claude Code, opencode). Sessions are keyed by the
+// tool's native session ID; events are per-turn timestamps only — no
+// transcript bodies are stored.
+func (s *Store) applyMigration15() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS ai_sessions (
+			id              TEXT PRIMARY KEY,
+			tool            TEXT NOT NULL,
+			project_dir     TEXT,
+			file_path       TEXT,
+			started_at      INTEGER NOT NULL,
+			last_event_at   INTEGER NOT NULL,
+			event_count     INTEGER NOT NULL DEFAULT 0,
+			source_offset   INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE INDEX IF NOT EXISTS idx_ai_sessions_last_event ON ai_sessions(last_event_at);
+		CREATE INDEX IF NOT EXISTS idx_ai_sessions_file_path   ON ai_sessions(file_path);
+
+		CREATE TABLE IF NOT EXISTS ai_events (
+			id           INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id   TEXT NOT NULL REFERENCES ai_sessions(id) ON DELETE CASCADE,
+			tool         TEXT NOT NULL,
+			kind         TEXT NOT NULL,
+			timestamp    INTEGER NOT NULL,
+			project_dir  TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_ai_events_ts      ON ai_events(timestamp);
+		CREATE INDEX IF NOT EXISTS idx_ai_events_session ON ai_events(session_id);
+		CREATE INDEX IF NOT EXISTS idx_ai_events_tool_ts ON ai_events(tool, timestamp);
+	`)
+	return err
 }

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -5,7 +5,7 @@ import (
 	"log"
 )
 
-const schemaVersion = 13
+const schemaVersion = 14
 
 const schema = `
 -- ============================================================================
@@ -112,11 +112,15 @@ CREATE TABLE IF NOT EXISTS shell_commands (
     hostname TEXT,
     tmux_context TEXT,
     session_id INTEGER REFERENCES sessions(id),
+    project_id INTEGER REFERENCES projects(id),
+    project_confidence REAL DEFAULT 0.0,
+    project_source TEXT DEFAULT 'unassigned',
     created_at INTEGER DEFAULT (strftime('%s', 'now'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_shell_timestamp ON shell_commands(timestamp);
 CREATE INDEX IF NOT EXISTS idx_shell_session ON shell_commands(session_id);
+CREATE INDEX IF NOT EXISTS idx_shell_project ON shell_commands(project_id);
 
 CREATE TABLE IF NOT EXISTS git_repositories (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -331,6 +335,12 @@ func (s *Store) Migrate() error {
 		// Migration v13: Add tmux_context column to shell_commands for plugin-sourced entries
 		if err := s.applyMigration13(); err != nil {
 			return fmt.Errorf("failed to apply migration 13: %w", err)
+		}
+	}
+	if currentVersion < 14 {
+		// Migration v14: Add project assignment columns to shell_commands
+		if err := s.applyMigration14(); err != nil {
+			return fmt.Errorf("failed to apply migration 14: %w", err)
 		}
 	}
 
@@ -948,6 +958,8 @@ func (s *Store) repairShellCommandsTable() {
 	if err != nil || tableCount == 0 {
 		return
 	}
+
+	// Migration 13: tmux_context
 	var colCount int
 	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'tmux_context'`).Scan(&colCount)
 	if err == nil && colCount == 0 {
@@ -957,6 +969,34 @@ func (s *Store) repairShellCommandsTable() {
 			log.Printf("repairShellCommandsTable: failed to add tmux_context column: %v", err)
 		}
 	}
+
+	// Migration 14: project assignment columns
+	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'project_id'`).Scan(&colCount)
+	if err == nil && colCount == 0 {
+		s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_id INTEGER REFERENCES projects(id)`)
+	}
+	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'project_confidence'`).Scan(&colCount)
+	if err == nil && colCount == 0 {
+		s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_confidence REAL DEFAULT 0.0`)
+	}
+	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'project_source'`).Scan(&colCount)
+	if err == nil && colCount == 0 {
+		s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_source TEXT DEFAULT 'unassigned'`)
+	}
+	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_shell_project ON shell_commands(project_id)`)
+}
+
+// applyMigration14 adds project assignment columns to shell_commands so shell
+// entries can be attributed to projects like screenshots / focus events / git commits.
+func (s *Store) applyMigration14() error {
+	// ALTER TABLE ADD COLUMN is idempotent-friendly via the repair path;
+	// any errors here (e.g. column already exists from a partial apply) are
+	// benign — repairShellCommandsTable also runs and guards on existence.
+	s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_id INTEGER REFERENCES projects(id)`)
+	s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_confidence REAL DEFAULT 0.0`)
+	s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN project_source TEXT DEFAULT 'unassigned'`)
+	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_shell_project ON shell_commands(project_id)`)
+	return nil
 }
 
 // applyMigration12 adds draft fields for AI summary approval workflow.

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -236,6 +236,12 @@ CREATE TABLE IF NOT EXISTS schema_version (
 
 // Migrate applies any pending database migrations.
 func (s *Store) Migrate() error {
+	// Always run repair first. This handles DBs whose schema_version was stamped
+	// at the target without the accompanying DDL (e.g. a partial/no-op migration
+	// from an intermediate dev build). Repair sub-functions guard on table
+	// existence, so this is a no-op on fresh DBs.
+	s.repairMissingTables()
+
 	// Check current schema version
 	var currentVersion int
 	err := s.db.QueryRow("SELECT COALESCE(MAX(version), 0) FROM schema_version").Scan(&currentVersion)
@@ -336,9 +342,6 @@ func (s *Store) Migrate() error {
 	if err != nil {
 		return fmt.Errorf("failed to update schema version: %w", err)
 	}
-
-	// Run repair checks for tables that might be missing due to partial migrations
-	s.repairMissingTables()
 
 	return nil
 }
@@ -947,7 +950,9 @@ func (s *Store) repairShellCommandsTable() {
 	var colCount int
 	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'tmux_context'`).Scan(&colCount)
 	if err == nil && colCount == 0 {
-		s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT`)
+		if _, err := s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT`); err != nil {
+			fmt.Printf("repairShellCommandsTable: failed to add tmux_context column: %v\n", err)
+		}
 	}
 }
 

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"log"
 )
 
 const schemaVersion = 13
@@ -951,7 +952,9 @@ func (s *Store) repairShellCommandsTable() {
 	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'tmux_context'`).Scan(&colCount)
 	if err == nil && colCount == 0 {
 		if _, err := s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT`); err != nil {
-			fmt.Printf("repairShellCommandsTable: failed to add tmux_context column: %v\n", err)
+			// Wails GUI has no attached console; fmt.Printf would vanish. Use
+			// the project logger so this surfaces in dev logs and log files.
+			log.Printf("repairShellCommandsTable: failed to add tmux_context column: %v", err)
 		}
 	}
 }

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -5,7 +5,7 @@ import (
 	"log"
 )
 
-const schemaVersion = 15
+const schemaVersion = 16
 
 const schema = `
 -- ============================================================================
@@ -351,6 +351,13 @@ func (s *Store) Migrate() error {
 		}
 	}
 
+	if currentVersion < 16 {
+		// Migration v16: Add content column to ai_events for prompt text
+		if err := s.applyMigration16(); err != nil {
+			return fmt.Errorf("failed to apply migration 16: %w", err)
+		}
+	}
+
 	// Record schema version
 	if currentVersion == 0 {
 		_, err = s.db.Exec("INSERT OR REPLACE INTO schema_version (version) VALUES (?)", schemaVersion)
@@ -377,6 +384,8 @@ func (s *Store) repairMissingTables() {
 	s.repairScreenshotsTable()
 	// Repair missing columns in shell_commands table (migration 13)
 	s.repairShellCommandsTable()
+	// Repair missing columns in ai_events (migration 16)
+	s.repairAIEventsTable()
 	// Check and create project_patterns table if missing
 	var count int
 	err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='project_patterns'`).Scan(&count)
@@ -1055,6 +1064,27 @@ func (s *Store) applyMigration12() error {
 	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_focus_draft ON window_focus_events(is_draft)`)
 
 	return nil
+}
+
+func (s *Store) repairAIEventsTable() {
+	var tableCount int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ai_events'`).Scan(&tableCount)
+	if err != nil || tableCount == 0 {
+		return
+	}
+	var colCount int
+	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('ai_events') WHERE name = 'content'`).Scan(&colCount)
+	if err == nil && colCount == 0 {
+		s.db.Exec(`ALTER TABLE ai_events ADD COLUMN content TEXT`)
+	}
+}
+
+// applyMigration16 adds a content column to ai_events to store the text of
+// user prompts (and later opencode-side role-normalized user messages). The
+// column is nullable so existing rows remain valid.
+func (s *Store) applyMigration16() error {
+	_, err := s.db.Exec(`ALTER TABLE ai_events ADD COLUMN content TEXT`)
+	return err
 }
 
 // applyMigration15 adds ai_sessions and ai_events tables for AI coding

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -1066,6 +1066,9 @@ func (s *Store) applyMigration12() error {
 	return nil
 }
 
+// repairAIEventsTable re-adds ai_events columns introduced after migration 15
+// that may be missing if an earlier dev build stamped schema_version past a
+// migration without running its DDL. Covers migration 16 (content).
 func (s *Store) repairAIEventsTable() {
 	var tableCount int
 	err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ai_events'`).Scan(&tableCount)
@@ -1073,18 +1076,43 @@ func (s *Store) repairAIEventsTable() {
 		return
 	}
 	var colCount int
-	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('ai_events') WHERE name = 'content'`).Scan(&colCount)
-	if err == nil && colCount == 0 {
-		s.db.Exec(`ALTER TABLE ai_events ADD COLUMN content TEXT`)
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('ai_events') WHERE name = 'content'`,
+	).Scan(&colCount); err != nil {
+		log.Printf("repairAIEventsTable: check content column: %v", err)
+		return
+	}
+	if colCount > 0 {
+		return
+	}
+	if _, err := s.db.Exec(`ALTER TABLE ai_events ADD COLUMN content TEXT`); err != nil {
+		log.Printf("repairAIEventsTable: add content column: %v", err)
 	}
 }
 
 // applyMigration16 adds a content column to ai_events to store the text of
 // user prompts (and later opencode-side role-normalized user messages). The
 // column is nullable so existing rows remain valid.
+//
+// Guarded with pragma_table_info so it no-ops when the column already
+// exists. Required because (a) the top-level schema const creates
+// ai_events with content already, so fresh installs would otherwise fail
+// with "duplicate column name", and (b) repairAIEventsTable runs before
+// the version-gated path and may have added the column on upgrade DBs.
 func (s *Store) applyMigration16() error {
-	_, err := s.db.Exec(`ALTER TABLE ai_events ADD COLUMN content TEXT`)
-	return err
+	var count int
+	if err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('ai_events') WHERE name = 'content'`,
+	).Scan(&count); err != nil {
+		return fmt.Errorf("check content column: %w", err)
+	}
+	if count > 0 {
+		return nil
+	}
+	if _, err := s.db.Exec(`ALTER TABLE ai_events ADD COLUMN content TEXT`); err != nil {
+		return fmt.Errorf("add content column: %w", err)
+	}
+	return nil
 }
 
 // applyMigration15 adds ai_sessions and ai_events tables for AI coding

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const schemaVersion = 12
+const schemaVersion = 13
 
 const schema = `
 -- ============================================================================
@@ -109,6 +109,7 @@ CREATE TABLE IF NOT EXISTS shell_commands (
     exit_code INTEGER,
     duration_seconds REAL,
     hostname TEXT,
+    tmux_context TEXT,
     session_id INTEGER REFERENCES sessions(id),
     created_at INTEGER DEFAULT (strftime('%s', 'now'))
 );
@@ -319,6 +320,12 @@ func (s *Store) Migrate() error {
 			return fmt.Errorf("failed to apply migration 12: %w", err)
 		}
 	}
+	if currentVersion < 13 {
+		// Migration v13: Add tmux_context column to shell_commands for plugin-sourced entries
+		if err := s.applyMigration13(); err != nil {
+			return fmt.Errorf("failed to apply migration 13: %w", err)
+		}
+	}
 
 	// Record schema version
 	if currentVersion == 0 {
@@ -347,6 +354,8 @@ func (s *Store) repairMissingTables() {
 	s.repairSummariesTable()
 	// Repair missing columns in screenshots table (migrations 9 & 10)
 	s.repairScreenshotsTable()
+	// Repair missing columns in shell_commands table (migration 13)
+	s.repairShellCommandsTable()
 	// Check and create project_patterns table if missing
 	var count int
 	err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='project_patterns'`).Scan(&count)
@@ -910,6 +919,36 @@ func (s *Store) applyMigration11() error {
 	s.db.Exec(`CREATE INDEX IF NOT EXISTS idx_embeddings_hash ON activity_embeddings(context_hash)`)
 
 	return nil
+}
+
+// applyMigration13 adds tmux_context column to shell_commands for plugin-sourced entries.
+func (s *Store) applyMigration13() error {
+	var count int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'tmux_context'`,
+	).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check tmux_context column: %w", err)
+	}
+	if count == 0 {
+		if _, err := s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT`); err != nil {
+			return fmt.Errorf("add tmux_context column: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) repairShellCommandsTable() {
+	var tableCount int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='shell_commands'`).Scan(&tableCount)
+	if err != nil || tableCount == 0 {
+		return
+	}
+	var colCount int
+	err = s.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'tmux_context'`).Scan(&colCount)
+	if err == nil && colCount == 0 {
+		s.db.Exec(`ALTER TABLE shell_commands ADD COLUMN tmux_context TEXT`)
+	}
 }
 
 // applyMigration12 adds draft fields for AI summary approval workflow.

--- a/internal/storage/migrations_shell_project_test.go
+++ b/internal/storage/migrations_shell_project_test.go
@@ -1,0 +1,80 @@
+package storage
+
+import (
+	"testing"
+)
+
+func TestMigration14_AddsShellProjectColumns(t *testing.T) {
+	store, cleanup := testStore(t)
+	defer cleanup()
+
+	expected := []string{"project_id", "project_confidence", "project_source"}
+	for _, col := range expected {
+		var count int
+		err := store.db.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = ?`,
+			col,
+		).Scan(&count)
+		if err != nil {
+			t.Fatalf("pragma_table_info(%s): %v", col, err)
+		}
+		if count != 1 {
+			t.Errorf("expected column %s on shell_commands, got count=%d", col, count)
+		}
+	}
+
+	// Assignment index should exist for project_id lookups.
+	var idxCount int
+	err := store.db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND tbl_name='shell_commands' AND name='idx_shell_project'`,
+	).Scan(&idxCount)
+	if err != nil {
+		t.Fatalf("index lookup failed: %v", err)
+	}
+	if idxCount != 1 {
+		t.Errorf("expected idx_shell_project index, got %d", idxCount)
+	}
+
+	var version int
+	if err := store.db.QueryRow(`SELECT version FROM schema_version`).Scan(&version); err != nil {
+		t.Fatalf("schema_version lookup failed: %v", err)
+	}
+	if version < 14 {
+		t.Errorf("expected schema version >= 14, got %d", version)
+	}
+}
+
+// Repair should add the columns even when schema_version is already stamped at 14.
+func TestRepairShellCommandsTable_AddsProjectColumns(t *testing.T) {
+	store, cleanup := testStore(t)
+	defer cleanup()
+
+	// Simulate a DB where schema_version is stamped but columns are missing.
+	// Drop the dependent index first so we can drop the indexed column.
+	if _, err := store.db.Exec(`DROP INDEX IF EXISTS idx_shell_project`); err != nil {
+		t.Fatalf("drop index: %v", err)
+	}
+	for _, col := range []string{"project_id", "project_confidence", "project_source"} {
+		if _, err := store.db.Exec(
+			`ALTER TABLE shell_commands DROP COLUMN ` + col,
+		); err != nil {
+			t.Fatalf("drop %s: %v", col, err)
+		}
+	}
+
+	store.repairShellCommandsTable()
+
+	for _, col := range []string{"project_id", "project_confidence", "project_source"} {
+		var count int
+		err := store.db.QueryRow(
+			`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = ?`,
+			col,
+		).Scan(&count)
+		if err != nil {
+			t.Fatalf("pragma_table_info(%s): %v", col, err)
+		}
+		if count != 1 {
+			t.Errorf("repair did not add column %s", col)
+		}
+	}
+}

--- a/internal/storage/migrations_shell_tmux_test.go
+++ b/internal/storage/migrations_shell_tmux_test.go
@@ -1,0 +1,30 @@
+package storage
+
+import (
+	"testing"
+)
+
+func TestMigration13_AddsTmuxContextColumn(t *testing.T) {
+	store, cleanup := testStore(t)
+	defer cleanup()
+
+	var count int
+	err := store.db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('shell_commands') WHERE name = 'tmux_context'`,
+	).Scan(&count)
+	if err != nil {
+		t.Fatalf("pragma_table_info failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected tmux_context column, got count=%d", count)
+	}
+
+	var version int
+	err = store.db.QueryRow(`SELECT version FROM schema_version`).Scan(&version)
+	if err != nil {
+		t.Fatalf("schema_version lookup failed: %v", err)
+	}
+	if version < 13 {
+		t.Fatalf("expected schema version >= 13, got %d", version)
+	}
+}

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -93,6 +93,7 @@ type ShellCommand struct {
 	ExitCode         sql.NullInt64   `json:"exitCode"`
 	DurationSeconds  sql.NullFloat64 `json:"durationSeconds"`
 	Hostname         sql.NullString  `json:"hostname"`
+	TmuxContext      sql.NullString  `json:"tmuxContext"`
 	SessionID        sql.NullInt64   `json:"sessionId"`
 	CreatedAt        int64           `json:"createdAt"`
 }

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -96,6 +96,10 @@ type ShellCommand struct {
 	TmuxContext      sql.NullString  `json:"tmuxContext"`
 	SessionID        sql.NullInt64   `json:"sessionId"`
 	CreatedAt        int64           `json:"createdAt"`
+
+	ProjectID         sql.NullInt64   `json:"projectId"`
+	ProjectConfidence sql.NullFloat64 `json:"projectConfidence"`
+	ProjectSource     sql.NullString  `json:"projectSource"`
 }
 
 // GitRepository represents a tracked git repository.

--- a/internal/storage/projects.go
+++ b/internal/storage/projects.go
@@ -268,17 +268,27 @@ func (s *Store) SetEventProject(eventType string, eventID, projectID int64, conf
 }
 
 // GetUnassignedEventCount returns count of events without project assignment.
+//
+// Uses `project_id IS NULL` rather than `project_source = 'unassigned'` so
+// each subquery can use the project_id index (idx_screenshots_project,
+// idx_focus_project, idx_git_project, idx_shell_project) instead of full
+// scans. These are the highest-volume tables in the DB and this function
+// drives a sidebar counter that refetches on timeline navigation.
+//
+// The two formulations are equivalent by construction: SetEventProject
+// always writes project_id and project_source together, so rows with
+// project_id IS NULL always have project_source in ('unassigned', NULL).
 func (s *Store) GetUnassignedEventCount() (int, error) {
 	var count int
 	err := s.db.QueryRow(`
 		SELECT (
-			SELECT COUNT(*) FROM screenshots WHERE project_source = 'unassigned' OR project_source IS NULL
+			SELECT COUNT(*) FROM screenshots WHERE project_id IS NULL
 		) + (
-			SELECT COUNT(*) FROM window_focus_events WHERE project_source = 'unassigned' OR project_source IS NULL
+			SELECT COUNT(*) FROM window_focus_events WHERE project_id IS NULL
 		) + (
-			SELECT COUNT(*) FROM git_commits WHERE project_source = 'unassigned' OR project_source IS NULL
+			SELECT COUNT(*) FROM git_commits WHERE project_id IS NULL
 		) + (
-			SELECT COUNT(*) FROM shell_commands WHERE project_source = 'unassigned' OR project_source IS NULL
+			SELECT COUNT(*) FROM shell_commands WHERE project_id IS NULL
 		)
 	`).Scan(&count)
 	if err != nil {

--- a/internal/storage/projects.go
+++ b/internal/storage/projects.go
@@ -113,6 +113,10 @@ func (s *Store) DeleteProject(id int64) error {
 	if err != nil {
 		return fmt.Errorf("failed to clear git commit assignments: %w", err)
 	}
+	_, err = s.db.Exec(`UPDATE shell_commands SET project_id = NULL, project_source = 'unassigned' WHERE project_id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("failed to clear shell command assignments: %w", err)
+	}
 
 	// Delete the project (cascades to patterns and examples)
 	_, err = s.db.Exec(`DELETE FROM projects WHERE id = ?`, id)
@@ -243,6 +247,8 @@ func (s *Store) SetEventProject(eventType string, eventID, projectID int64, conf
 		query = `UPDATE window_focus_events SET project_id = ?, project_confidence = ?, project_source = ? WHERE id = ?`
 	case "git":
 		query = `UPDATE git_commits SET project_id = ?, project_confidence = ?, project_source = ? WHERE id = ?`
+	case "shell":
+		query = `UPDATE shell_commands SET project_id = ?, project_confidence = ?, project_source = ? WHERE id = ?`
 	default:
 		return fmt.Errorf("unknown event type: %s", eventType)
 	}
@@ -271,6 +277,8 @@ func (s *Store) GetUnassignedEventCount() (int, error) {
 			SELECT COUNT(*) FROM window_focus_events WHERE project_source = 'unassigned' OR project_source IS NULL
 		) + (
 			SELECT COUNT(*) FROM git_commits WHERE project_source = 'unassigned' OR project_source IS NULL
+		) + (
+			SELECT COUNT(*) FROM shell_commands WHERE project_source = 'unassigned' OR project_source IS NULL
 		)
 	`).Scan(&count)
 	if err != nil {

--- a/internal/storage/projects_shell_test.go
+++ b/internal/storage/projects_shell_test.go
@@ -1,0 +1,144 @@
+package storage
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func TestGetUnassignedEventCount_IncludesShellCommands(t *testing.T) {
+	store, cleanup := testStore(t)
+	defer cleanup()
+
+	project, err := store.CreateProject("traq", "#6366f1", "")
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	// 3 shell commands, 2 unassigned + 1 assigned.
+	var assignedID int64
+	for i := 0; i < 3; i++ {
+		id, err := store.SaveShellCommand(&ShellCommand{
+			Timestamp: time.Now().Unix() + int64(i),
+			Command:   "echo hi",
+			ShellType: "bash",
+		})
+		if err != nil {
+			t.Fatalf("save: %v", err)
+		}
+		if i == 0 {
+			assignedID = id
+		}
+	}
+	if err := store.SetEventProject("shell", assignedID, project.ID, 1.0, "user"); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+
+	count, err := store.GetUnassignedEventCount()
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	// Exactly 2 unassigned shell commands should contribute; no other events exist.
+	if count != 2 {
+		t.Errorf("expected 2 unassigned, got %d", count)
+	}
+}
+
+func TestDeleteProject_ClearsShellAssignments(t *testing.T) {
+	store, cleanup := testStore(t)
+	defer cleanup()
+
+	project, err := store.CreateProject("traq", "#6366f1", "")
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	id, err := store.SaveShellCommand(&ShellCommand{
+		Timestamp: time.Now().Unix(),
+		Command:   "ls",
+		ShellType: "bash",
+	})
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := store.SetEventProject("shell", id, project.ID, 1.0, "user"); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+
+	if err := store.DeleteProject(project.ID); err != nil {
+		t.Fatalf("delete project: %v", err)
+	}
+
+	var gotProjectID sql.NullInt64
+	var gotSource sql.NullString
+	if err := store.db.QueryRow(
+		`SELECT project_id, project_source FROM shell_commands WHERE id = ?`, id,
+	).Scan(&gotProjectID, &gotSource); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if gotProjectID.Valid {
+		t.Errorf("expected NULL project_id after project delete, got %+v", gotProjectID)
+	}
+	if gotSource.String != "unassigned" {
+		t.Errorf("source: want unassigned, got %q", gotSource.String)
+	}
+}
+
+func TestSetEventProject_Shell_AssignsAndUnassigns(t *testing.T) {
+	store, cleanup := testStore(t)
+	defer cleanup()
+
+	project, err := store.CreateProject("traq", "#6366f1", "")
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	id, err := store.SaveShellCommand(&ShellCommand{
+		Timestamp:        time.Now().Unix(),
+		Command:          "go test ./...",
+		ShellType:        "bash",
+		WorkingDirectory: sql.NullString{String: "/home/jl/repos/traq", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("save shell command: %v", err)
+	}
+
+	// Assign to project.
+	if err := store.SetEventProject("shell", id, project.ID, 1.0, "user"); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+
+	var gotProjectID sql.NullInt64
+	var gotConf sql.NullFloat64
+	var gotSource sql.NullString
+	if err := store.db.QueryRow(
+		`SELECT project_id, project_confidence, project_source FROM shell_commands WHERE id = ?`, id,
+	).Scan(&gotProjectID, &gotConf, &gotSource); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if !gotProjectID.Valid || gotProjectID.Int64 != project.ID {
+		t.Errorf("project_id: want %d, got %+v", project.ID, gotProjectID)
+	}
+	if gotConf.Float64 != 1.0 {
+		t.Errorf("confidence: want 1.0, got %v", gotConf.Float64)
+	}
+	if gotSource.String != "user" {
+		t.Errorf("source: want user, got %q", gotSource.String)
+	}
+
+	// Unassign (projectID == 0 is the documented contract).
+	if err := store.SetEventProject("shell", id, 0, 0, ""); err != nil {
+		t.Fatalf("unassign: %v", err)
+	}
+	if err := store.db.QueryRow(
+		`SELECT project_id, project_confidence, project_source FROM shell_commands WHERE id = ?`, id,
+	).Scan(&gotProjectID, &gotConf, &gotSource); err != nil {
+		t.Fatalf("select after unassign: %v", err)
+	}
+	if gotProjectID.Valid {
+		t.Errorf("expected NULL project_id after unassign, got %+v", gotProjectID)
+	}
+	if gotSource.String != "unassigned" {
+		t.Errorf("source after unassign: want unassigned, got %q", gotSource.String)
+	}
+}

--- a/internal/storage/shell.go
+++ b/internal/storage/shell.go
@@ -10,10 +10,10 @@ func (s *Store) SaveShellCommand(cmd *ShellCommand) (int64, error) {
 	result, err := s.db.Exec(`
 		INSERT INTO shell_commands (
 			timestamp, command, shell_type, working_directory,
-			exit_code, duration_seconds, hostname, session_id
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			exit_code, duration_seconds, hostname, tmux_context, session_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		cmd.Timestamp, cmd.Command, cmd.ShellType, cmd.WorkingDirectory,
-		cmd.ExitCode, cmd.DurationSeconds, cmd.Hostname, cmd.SessionID,
+		cmd.ExitCode, cmd.DurationSeconds, cmd.Hostname, cmd.TmuxContext, cmd.SessionID,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("failed to insert shell command: %w", err)
@@ -31,7 +31,7 @@ func (s *Store) SaveShellCommand(cmd *ShellCommand) (int64, error) {
 func (s *Store) GetShellCommandsBySession(sessionID int64) ([]*ShellCommand, error) {
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, command, shell_type, working_directory,
-		       exit_code, duration_seconds, hostname, session_id, created_at
+		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at
 		FROM shell_commands
 		WHERE session_id = ?
 		ORDER BY timestamp ASC`, sessionID)
@@ -47,7 +47,7 @@ func (s *Store) GetShellCommandsBySession(sessionID int64) ([]*ShellCommand, err
 func (s *Store) GetShellCommandsByTimeRange(start, end int64) ([]*ShellCommand, error) {
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, command, shell_type, working_directory,
-		       exit_code, duration_seconds, hostname, session_id, created_at
+		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at
 		FROM shell_commands
 		WHERE timestamp >= ? AND timestamp <= ?
 		ORDER BY timestamp ASC`, start, end)
@@ -63,7 +63,7 @@ func (s *Store) GetShellCommandsByTimeRange(start, end int64) ([]*ShellCommand, 
 func (s *Store) GetRecentShellCommands(limit int) ([]*ShellCommand, error) {
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, command, shell_type, working_directory,
-		       exit_code, duration_seconds, hostname, session_id, created_at
+		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at
 		FROM shell_commands
 		ORDER BY timestamp DESC
 		LIMIT ?`, limit)
@@ -111,7 +111,7 @@ func (s *Store) CountShellCommandsByTimeRange(start, end int64) (int64, error) {
 func (s *Store) GetAllShellCommands() ([]*ShellCommand, error) {
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, command, shell_type, working_directory,
-		       exit_code, duration_seconds, hostname, session_id, created_at
+		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at
 		FROM shell_commands
 		ORDER BY timestamp DESC`)
 	if err != nil {
@@ -127,7 +127,7 @@ func (s *Store) SearchShellCommands(query string, limit int) ([]*ShellCommand, e
 	likeQuery := "%" + query + "%"
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, command, shell_type, working_directory,
-		       exit_code, duration_seconds, hostname, session_id, created_at
+		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at
 		FROM shell_commands
 		WHERE command LIKE ?
 		ORDER BY timestamp DESC
@@ -234,7 +234,8 @@ func scanShellCommands(rows *sql.Rows) ([]*ShellCommand, error) {
 		cmd := &ShellCommand{}
 		err := rows.Scan(
 			&cmd.ID, &cmd.Timestamp, &cmd.Command, &cmd.ShellType, &cmd.WorkingDirectory,
-			&cmd.ExitCode, &cmd.DurationSeconds, &cmd.Hostname, &cmd.SessionID, &cmd.CreatedAt,
+			&cmd.ExitCode, &cmd.DurationSeconds, &cmd.Hostname, &cmd.TmuxContext,
+			&cmd.SessionID, &cmd.CreatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan shell command: %w", err)

--- a/internal/storage/shell.go
+++ b/internal/storage/shell.go
@@ -31,7 +31,8 @@ func (s *Store) SaveShellCommand(cmd *ShellCommand) (int64, error) {
 func (s *Store) GetShellCommandsBySession(sessionID int64) ([]*ShellCommand, error) {
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, command, shell_type, working_directory,
-		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at
+		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at,
+		       project_id, project_confidence, project_source
 		FROM shell_commands
 		WHERE session_id = ?
 		ORDER BY timestamp ASC`, sessionID)
@@ -47,7 +48,8 @@ func (s *Store) GetShellCommandsBySession(sessionID int64) ([]*ShellCommand, err
 func (s *Store) GetShellCommandsByTimeRange(start, end int64) ([]*ShellCommand, error) {
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, command, shell_type, working_directory,
-		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at
+		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at,
+		       project_id, project_confidence, project_source
 		FROM shell_commands
 		WHERE timestamp >= ? AND timestamp <= ?
 		ORDER BY timestamp ASC`, start, end)
@@ -63,7 +65,8 @@ func (s *Store) GetShellCommandsByTimeRange(start, end int64) ([]*ShellCommand, 
 func (s *Store) GetRecentShellCommands(limit int) ([]*ShellCommand, error) {
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, command, shell_type, working_directory,
-		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at
+		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at,
+		       project_id, project_confidence, project_source
 		FROM shell_commands
 		ORDER BY timestamp DESC
 		LIMIT ?`, limit)
@@ -111,7 +114,8 @@ func (s *Store) CountShellCommandsByTimeRange(start, end int64) (int64, error) {
 func (s *Store) GetAllShellCommands() ([]*ShellCommand, error) {
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, command, shell_type, working_directory,
-		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at
+		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at,
+		       project_id, project_confidence, project_source
 		FROM shell_commands
 		ORDER BY timestamp DESC`)
 	if err != nil {
@@ -127,7 +131,8 @@ func (s *Store) SearchShellCommands(query string, limit int) ([]*ShellCommand, e
 	likeQuery := "%" + query + "%"
 	rows, err := s.db.Query(`
 		SELECT id, timestamp, command, shell_type, working_directory,
-		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at
+		       exit_code, duration_seconds, hostname, tmux_context, session_id, created_at,
+		       project_id, project_confidence, project_source
 		FROM shell_commands
 		WHERE command LIKE ?
 		ORDER BY timestamp DESC
@@ -236,6 +241,7 @@ func scanShellCommands(rows *sql.Rows) ([]*ShellCommand, error) {
 			&cmd.ID, &cmd.Timestamp, &cmd.Command, &cmd.ShellType, &cmd.WorkingDirectory,
 			&cmd.ExitCode, &cmd.DurationSeconds, &cmd.Hostname, &cmd.TmuxContext,
 			&cmd.SessionID, &cmd.CreatedAt,
+			&cmd.ProjectID, &cmd.ProjectConfidence, &cmd.ProjectSource,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan shell command: %w", err)

--- a/internal/storage/shell_project_read_test.go
+++ b/internal/storage/shell_project_read_test.go
@@ -1,0 +1,46 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetRecentShellCommands_ExposesProjectAssignment(t *testing.T) {
+	store, cleanup := testStore(t)
+	defer cleanup()
+
+	project, err := store.CreateProject("traq", "#6366f1", "")
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	id, err := store.SaveShellCommand(&ShellCommand{
+		Timestamp: time.Now().Unix(),
+		Command:   "go test ./...",
+		ShellType: "bash",
+	})
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := store.SetEventProject("shell", id, project.ID, 1.0, "user"); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+
+	cmds, err := store.GetRecentShellCommands(10)
+	if err != nil {
+		t.Fatalf("get recent: %v", err)
+	}
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(cmds))
+	}
+	got := cmds[0]
+	if !got.ProjectID.Valid || got.ProjectID.Int64 != project.ID {
+		t.Errorf("ProjectID: want %d, got %+v", project.ID, got.ProjectID)
+	}
+	if got.ProjectConfidence.Float64 != 1.0 {
+		t.Errorf("ProjectConfidence: want 1.0, got %v", got.ProjectConfidence.Float64)
+	}
+	if got.ProjectSource.String != "user" {
+		t.Errorf("ProjectSource: want user, got %q", got.ProjectSource.String)
+	}
+}

--- a/internal/storage/testing.go
+++ b/internal/storage/testing.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// NewInMemoryTestStore returns a Store backed by an on-disk SQLite DB under
+// t.TempDir() (cleaned up automatically). Migrations are applied.
+func NewInMemoryTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := NewStore(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	return store
+}

--- a/internal/tracker/ai.go
+++ b/internal/tracker/ai.go
@@ -1,0 +1,103 @@
+package tracker
+
+import (
+	"context"
+	"time"
+
+	"traq/internal/storage"
+	"traq/internal/tracker/aiplugin"
+)
+
+// AITracker polls a set of AIPlugins and persists the events they return.
+// Safe to call Poll from at most one goroutine at a time.
+type AITracker struct {
+	store   *storage.Store
+	plugins []aiplugin.AIPlugin
+}
+
+func NewAITracker(store *storage.Store, plugins []aiplugin.AIPlugin) *AITracker {
+	return &AITracker{store: store, plugins: plugins}
+}
+
+// Poll queries every available plugin once and writes new events to storage.
+// Errors from a single plugin do not stop other plugins.
+func (t *AITracker) Poll() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, p := range t.plugins {
+		if !p.Available() {
+			continue
+		}
+		events, err := p.Poll(ctx, t.store)
+		if err != nil || len(events) == 0 {
+			continue
+		}
+		_ = t.persist(events)
+	}
+	return nil
+}
+
+// persist groups events by (tool, session) and upserts each session row with
+// the last event's file offset, then bulk-inserts the events.
+func (t *AITracker) persist(events []aiplugin.AIEvent) error {
+	type key struct{ tool, session string }
+	groups := map[key][]aiplugin.AIEvent{}
+	order := []key{}
+	for _, e := range events {
+		k := key{e.Tool, e.SessionID}
+		if _, seen := groups[k]; !seen {
+			order = append(order, k)
+		}
+		groups[k] = append(groups[k], e)
+	}
+
+	for _, k := range order {
+		g := groups[k]
+		last := g[len(g)-1]
+
+		var existing *storage.AISession
+		if last.FilePath != "" {
+			existing, _ = t.store.GetAISessionByFilePath(last.FilePath)
+		}
+		if existing == nil {
+			existing, _ = t.store.GetAISessionByID(last.SessionID)
+		}
+
+		startedAt := g[0].Timestamp.Unix()
+		existingCount := 0
+		if existing != nil {
+			startedAt = existing.StartedAt
+			existingCount = existing.EventCount
+		}
+
+		sess := &storage.AISession{
+			ID:           last.SessionID,
+			Tool:         last.Tool,
+			ProjectDir:   last.ProjectDir,
+			FilePath:     last.FilePath,
+			StartedAt:    startedAt,
+			LastEventAt:  last.Timestamp.Unix(),
+			EventCount:   existingCount + len(g),
+			SourceOffset: last.Offset,
+		}
+		if err := t.store.UpsertAISession(sess); err != nil {
+			return err
+		}
+
+		dbEvents := make([]storage.AIEvent, 0, len(g))
+		for _, e := range g {
+			dbEvents = append(dbEvents, storage.AIEvent{
+				SessionID:  e.SessionID,
+				Tool:       e.Tool,
+				Kind:       e.Kind,
+				Timestamp:  e.Timestamp.Unix(),
+				ProjectDir: e.ProjectDir,
+			})
+		}
+		if err := t.store.InsertAIEvents(dbEvents); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/tracker/ai.go
+++ b/internal/tracker/ai.go
@@ -93,6 +93,7 @@ func (t *AITracker) persist(events []aiplugin.AIEvent) error {
 				Kind:       e.Kind,
 				Timestamp:  e.Timestamp.Unix(),
 				ProjectDir: e.ProjectDir,
+				Content:    e.Content,
 			})
 		}
 		if err := t.store.InsertAIEvents(dbEvents); err != nil {

--- a/internal/tracker/ai.go
+++ b/internal/tracker/ai.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"traq/internal/storage"
@@ -30,10 +31,19 @@ func (t *AITracker) Poll() error {
 			continue
 		}
 		events, err := p.Poll(ctx, t.store)
-		if err != nil || len(events) == 0 {
+		if err != nil {
+			// Surface continuous plugin failures so they're debuggable. The
+			// previous form swallowed errors silently, which masked e.g. a
+			// malformed JSONL file that would never succeed on retry.
+			log.Printf("AITracker: plugin %T poll failed: %v", p, err)
 			continue
 		}
-		_ = t.persist(events)
+		if len(events) == 0 {
+			continue
+		}
+		if err := t.persist(events); err != nil {
+			log.Printf("AITracker: persist events from %T: %v", p, err)
+		}
 	}
 	return nil
 }

--- a/internal/tracker/ai.go
+++ b/internal/tracker/ai.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"context"
 	"log"
+	"sync"
 	"time"
 
 	"traq/internal/storage"
@@ -10,23 +11,68 @@ import (
 )
 
 // AITracker polls a set of AIPlugins and persists the events they return.
-// Safe to call Poll from at most one goroutine at a time.
+// Safe to call Poll from at most one goroutine at a time. Enable flags are
+// guarded by mu so the user-facing Settings toggles can be applied between
+// poll ticks without restarting the daemon.
 type AITracker struct {
 	store   *storage.Store
 	plugins []aiplugin.AIPlugin
+
+	mu          sync.RWMutex
+	enabled     bool
+	toolEnabled map[string]bool
 }
 
 func NewAITracker(store *storage.Store, plugins []aiplugin.AIPlugin) *AITracker {
-	return &AITracker{store: store, plugins: plugins}
+	tools := make(map[string]bool, len(plugins))
+	for _, p := range plugins {
+		tools[p.Name()] = true
+	}
+	return &AITracker{
+		store:       store,
+		plugins:     plugins,
+		enabled:     true,
+		toolEnabled: tools,
+	}
+}
+
+// SetEnabled toggles the master AI-tracking switch. When false, Poll is a
+// no-op regardless of per-tool flags. Takes effect on the next Poll tick.
+func (t *AITracker) SetEnabled(on bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.enabled = on
+}
+
+// SetToolEnabled toggles a single plugin by its Name(). Unknown names are
+// recorded so a plugin added later can still pick up the configured value.
+func (t *AITracker) SetToolEnabled(name string, on bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.toolEnabled[name] = on
 }
 
 // Poll queries every available plugin once and writes new events to storage.
 // Errors from a single plugin do not stop other plugins.
 func (t *AITracker) Poll() error {
+	t.mu.RLock()
+	if !t.enabled {
+		t.mu.RUnlock()
+		return nil
+	}
+	enabled := make(map[string]bool, len(t.toolEnabled))
+	for k, v := range t.toolEnabled {
+		enabled[k] = v
+	}
+	t.mu.RUnlock()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	for _, p := range t.plugins {
+		if !enabled[p.Name()] {
+			continue
+		}
 		if !p.Available() {
 			continue
 		}

--- a/internal/tracker/ai_test.go
+++ b/internal/tracker/ai_test.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,5 +57,56 @@ func TestAITrackerPersistsClaudeEvents(t *testing.T) {
 	after, _ := store.GetAIEventsInRange(0, 1<<62)
 	if len(after) != 2 {
 		t.Fatalf("expected no duplicate ingest, got %d total events", len(after))
+	}
+}
+
+// stubPlugin records Poll calls; lets us assert which plugins ran without
+// touching the disk readers.
+type stubPlugin struct {
+	name   string
+	polled int
+}
+
+func (s *stubPlugin) Name() string { return s.name }
+func (s *stubPlugin) Available() bool { return true }
+func (s *stubPlugin) Poll(_ context.Context, _ *storage.Store) ([]aiplugin.AIEvent, error) {
+	s.polled++
+	return nil, nil
+}
+
+func TestAITrackerPollSkipsDisabledTool(t *testing.T) {
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	claude := &stubPlugin{name: "claude"}
+	opencode := &stubPlugin{name: "opencode"}
+	tr := NewAITracker(store, []aiplugin.AIPlugin{claude, opencode})
+	tr.SetToolEnabled("claude", false)
+
+	if err := tr.Poll(); err != nil {
+		t.Fatal(err)
+	}
+	if claude.polled != 0 {
+		t.Errorf("disabled claude polled %d times, want 0", claude.polled)
+	}
+	if opencode.polled != 1 {
+		t.Errorf("opencode polled %d times, want 1", opencode.polled)
+	}
+}
+
+func TestAITrackerPollNoOpWhenDisabled(t *testing.T) {
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	claude := &stubPlugin{name: "claude"}
+	opencode := &stubPlugin{name: "opencode"}
+	tr := NewAITracker(store, []aiplugin.AIPlugin{claude, opencode})
+	tr.SetEnabled(false)
+
+	if err := tr.Poll(); err != nil {
+		t.Fatal(err)
+	}
+	if claude.polled != 0 || opencode.polled != 0 {
+		t.Errorf("master-disabled tracker polled plugins: claude=%d opencode=%d", claude.polled, opencode.polled)
 	}
 }

--- a/internal/tracker/ai_test.go
+++ b/internal/tracker/ai_test.go
@@ -1,0 +1,60 @@
+package tracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"traq/internal/storage"
+	"traq/internal/tracker/aiplugin"
+)
+
+func TestAITrackerPersistsClaudeEvents(t *testing.T) {
+	root := t.TempDir()
+	proj := filepath.Join(root, "-home-u-repo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"type":"user","sessionId":"s","cwd":"/home/u/repo","timestamp":"2026-04-23T10:00:00Z","message":{"role":"user","content":"a"}}
+{"type":"assistant","sessionId":"s","cwd":"/home/u/repo","timestamp":"2026-04-23T10:00:05Z","message":{"role":"assistant","content":[{"type":"text","text":"b"}]}}
+`
+	path := filepath.Join(proj, "s.jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	tr := NewAITracker(store, []aiplugin.AIPlugin{aiplugin.NewClaudePlugin(root)})
+	if err := tr.Poll(); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	events, err := store.GetAIEventsInRange(0, 1<<62)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 persisted events, got %d", len(events))
+	}
+
+	sess, err := store.GetAISessionByFilePath(path)
+	if err != nil || sess == nil {
+		t.Fatalf("session not persisted: err=%v sess=%v", err, sess)
+	}
+	if sess.EventCount != 2 {
+		t.Errorf("EventCount=%d want 2", sess.EventCount)
+	}
+	if sess.SourceOffset == 0 {
+		t.Errorf("SourceOffset should be >0 after ingest")
+	}
+
+	if err := tr.Poll(); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := store.GetAIEventsInRange(0, 1<<62)
+	if len(after) != 2 {
+		t.Fatalf("expected no duplicate ingest, got %d total events", len(after))
+	}
+}

--- a/internal/tracker/aiplugin/plugin.go
+++ b/internal/tracker/aiplugin/plugin.go
@@ -1,0 +1,34 @@
+// Package aiplugin defines the interface AI coding session trackers implement.
+// Each plugin (claude, opencode) reads from an external on-disk data source
+// and returns normalized events that AITracker persists to storage.
+package aiplugin
+
+import (
+	"context"
+	"time"
+
+	"traq/internal/storage"
+)
+
+// AIEvent is the in-memory representation of one atomic event from an AI
+// tool's log. It is not the same as storage.AIEvent (which has an int64
+// timestamp and DB id); AITracker converts and persists these.
+type AIEvent struct {
+	Tool       string // "claude" | "opencode"
+	SessionID  string // tool's native session ID
+	ProjectDir string // absolute path or "" if unknown
+	Timestamp  time.Time
+	Kind       string // "user_prompt" | "assistant_turn" | "tool_use" | "message"
+	FilePath   string // source JSONL path (claude) or "" (opencode)
+	// Offset is the byte position *after* this event within FilePath.
+	// Claude sets this so AITracker can persist source_offset; opencode
+	// leaves it zero.
+	Offset int64
+}
+
+// AIPlugin is a single source of AI activity.
+type AIPlugin interface {
+	Name() string
+	Available() bool
+	Poll(ctx context.Context, store *storage.Store) ([]AIEvent, error)
+}

--- a/internal/tracker/aiplugin/plugin.go
+++ b/internal/tracker/aiplugin/plugin.go
@@ -18,12 +18,15 @@ type AIEvent struct {
 	SessionID  string // tool's native session ID
 	ProjectDir string // absolute path or "" if unknown
 	Timestamp  time.Time
-	Kind       string // "user_prompt" | "assistant_turn" | "tool_use" | "message"
+	Kind       string // "user_prompt" | "assistant_turn" | "tool_use"
 	FilePath   string // source JSONL path (claude) or "" (opencode)
 	// Offset is the byte position *after* this event within FilePath.
 	// Claude sets this so AITracker can persist source_offset; opencode
 	// leaves it zero.
 	Offset int64
+	// Content is the raw user prompt text for user_prompt events, empty
+	// otherwise. Stored verbatim (no server-side truncation).
+	Content string
 }
 
 // AIPlugin is a single source of AI activity.

--- a/internal/tracker/aiplugin/plugin_claude.go
+++ b/internal/tracker/aiplugin/plugin_claude.go
@@ -1,0 +1,161 @@
+package aiplugin
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"traq/internal/storage"
+)
+
+const toolClaude = "claude"
+
+// ClaudePlugin tails Claude Code JSONL session files in <root>/<project-slug>/*.jsonl.
+type ClaudePlugin struct {
+	root string // ~/.claude/projects (or a fixture root in tests)
+}
+
+func NewClaudePlugin(root string) *ClaudePlugin {
+	return &ClaudePlugin{root: root}
+}
+
+func (p *ClaudePlugin) Name() string { return toolClaude }
+
+func (p *ClaudePlugin) Available() bool {
+	info, err := os.Stat(p.root)
+	return err == nil && info.IsDir()
+}
+
+// claudeLine matches the fields the plugin cares about. Bodies and snapshot
+// contents are ignored by design — only metadata is stored downstream.
+type claudeLine struct {
+	Type      string    `json:"type"`
+	SessionID string    `json:"sessionId"`
+	CWD       string    `json:"cwd"`
+	Timestamp time.Time `json:"timestamp"`
+	Message   struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+func (p *ClaudePlugin) Poll(ctx context.Context, store *storage.Store) ([]AIEvent, error) {
+	var out []AIEvent
+
+	matches, err := filepath.Glob(filepath.Join(p.root, "*", "*.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range matches {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+		events, err := p.readFile(path, store)
+		if err != nil {
+			// Don't fail the whole poll for one bad file.
+			continue
+		}
+		out = append(out, events...)
+	}
+	return out, nil
+}
+
+func (p *ClaudePlugin) readFile(path string, store *storage.Store) ([]AIEvent, error) {
+	sess, err := store.GetAISessionByFilePath(path)
+	if err != nil {
+		return nil, err
+	}
+	var startOffset int64
+	if sess != nil {
+		startOffset = sess.SourceOffset
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(startOffset, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	var events []AIEvent
+	pos := startOffset
+	reader := bufio.NewReader(f)
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			pos += int64(len(line))
+			if ev, ok := parseClaudeLine(line, path, pos); ok {
+				events = append(events, ev)
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return events, err
+		}
+	}
+	return events, nil
+}
+
+func parseClaudeLine(line []byte, filePath string, offsetAfter int64) (AIEvent, bool) {
+	var cl claudeLine
+	if err := json.Unmarshal(line, &cl); err != nil {
+		return AIEvent{}, false
+	}
+	kind := claudeKind(&cl)
+	if kind == "" {
+		return AIEvent{}, false
+	}
+	if cl.SessionID == "" || cl.Timestamp.IsZero() {
+		return AIEvent{}, false
+	}
+	return AIEvent{
+		Tool:       toolClaude,
+		SessionID:  cl.SessionID,
+		ProjectDir: cl.CWD,
+		Timestamp:  cl.Timestamp,
+		Kind:       kind,
+		FilePath:   filePath,
+		Offset:     offsetAfter,
+	}, true
+}
+
+func claudeKind(cl *claudeLine) string {
+	switch cl.Type {
+	case "user":
+		return "user_prompt"
+	case "assistant":
+		if containsToolUse(cl.Message.Content) {
+			return "tool_use"
+		}
+		return "assistant_turn"
+	default:
+		return ""
+	}
+}
+
+func containsToolUse(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var items []struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return false
+	}
+	for _, it := range items {
+		if it.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tracker/aiplugin/plugin_claude.go
+++ b/internal/tracker/aiplugin/plugin_claude.go
@@ -17,11 +17,19 @@ const toolClaude = "claude"
 
 // ClaudePlugin tails Claude Code JSONL session files in <root>/<project-slug>/*.jsonl.
 type ClaudePlugin struct {
-	root string // ~/.claude/projects (or a fixture root in tests)
+	root               string // ~/.claude/projects (or a fixture root in tests)
+	storePromptContent bool
 }
 
 func NewClaudePlugin(root string) *ClaudePlugin {
 	return &ClaudePlugin{root: root}
+}
+
+// SetStorePromptContent enables/disables storage of verbatim user-prompt
+// text on emitted events. Off by default — aligns with the design doc's
+// "no transcript storage by default" privacy claim.
+func (p *ClaudePlugin) SetStorePromptContent(v bool) {
+	p.storePromptContent = v
 }
 
 func (p *ClaudePlugin) Name() string { return toolClaude }
@@ -93,7 +101,7 @@ func (p *ClaudePlugin) readFile(path string, store *storage.Store) ([]AIEvent, e
 		line, err := reader.ReadBytes('\n')
 		if len(line) > 0 {
 			pos += int64(len(line))
-			if ev, ok := parseClaudeLine(line, path, pos); ok {
+			if ev, ok := parseClaudeLine(line, path, pos, p.storePromptContent); ok {
 				events = append(events, ev)
 			}
 		}
@@ -107,7 +115,7 @@ func (p *ClaudePlugin) readFile(path string, store *storage.Store) ([]AIEvent, e
 	return events, nil
 }
 
-func parseClaudeLine(line []byte, filePath string, offsetAfter int64) (AIEvent, bool) {
+func parseClaudeLine(line []byte, filePath string, offsetAfter int64, storePromptContent bool) (AIEvent, bool) {
 	var cl claudeLine
 	if err := json.Unmarshal(line, &cl); err != nil {
 		return AIEvent{}, false
@@ -118,6 +126,12 @@ func parseClaudeLine(line []byte, filePath string, offsetAfter int64) (AIEvent, 
 	}
 	if cl.SessionID == "" || cl.Timestamp.IsZero() {
 		return AIEvent{}, false
+	}
+	// Respect the privacy toggle. The kind="user_prompt" event is still
+	// emitted so the timeline can show the marker; only the text body is
+	// dropped.
+	if !storePromptContent {
+		content = ""
 	}
 	return AIEvent{
 		Tool:       toolClaude,

--- a/internal/tracker/aiplugin/plugin_claude.go
+++ b/internal/tracker/aiplugin/plugin_claude.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"traq/internal/storage"
@@ -37,6 +38,7 @@ type claudeLine struct {
 	SessionID string    `json:"sessionId"`
 	CWD       string    `json:"cwd"`
 	Timestamp time.Time `json:"timestamp"`
+	IsMeta    bool      `json:"isMeta"`
 	Message   struct {
 		Role    string          `json:"role"`
 		Content json.RawMessage `json:"content"`
@@ -110,7 +112,7 @@ func parseClaudeLine(line []byte, filePath string, offsetAfter int64) (AIEvent, 
 	if err := json.Unmarshal(line, &cl); err != nil {
 		return AIEvent{}, false
 	}
-	kind := claudeKind(&cl)
+	kind, content := claudeKind(&cl)
 	if kind == "" {
 		return AIEvent{}, false
 	}
@@ -125,21 +127,68 @@ func parseClaudeLine(line []byte, filePath string, offsetAfter int64) (AIEvent, 
 		Kind:       kind,
 		FilePath:   filePath,
 		Offset:     offsetAfter,
+		Content:    content,
 	}, true
 }
 
-func claudeKind(cl *claudeLine) string {
+// claudeKind classifies a line and, for user prompts, returns the extracted
+// text. Meta messages and tool-result user messages are skipped — they
+// aren't prompts the user typed.
+func claudeKind(cl *claudeLine) (string, string) {
 	switch cl.Type {
 	case "user":
-		return "user_prompt"
+		if cl.IsMeta {
+			return "", ""
+		}
+		text, ok := extractUserPromptText(cl.Message.Content)
+		if !ok {
+			return "", ""
+		}
+		return "user_prompt", text
 	case "assistant":
 		if containsToolUse(cl.Message.Content) {
-			return "tool_use"
+			return "tool_use", ""
 		}
-		return "assistant_turn"
+		return "assistant_turn", ""
 	default:
-		return ""
+		return "", ""
 	}
+}
+
+// extractUserPromptText pulls the prompt text out of Claude's user message
+// content. Content can be either a bare string or an array of typed blocks.
+// Lines whose content is only tool results are rejected (ok=false).
+func extractUserPromptText(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	// Bare string form.
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, true
+	}
+	// Array-of-blocks form.
+	var items []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return "", false
+	}
+	var parts []string
+	sawNonToolResult := false
+	for _, it := range items {
+		if it.Type != "tool_result" {
+			sawNonToolResult = true
+		}
+		if it.Type == "text" && it.Text != "" {
+			parts = append(parts, it.Text)
+		}
+	}
+	if !sawNonToolResult {
+		return "", false
+	}
+	return strings.Join(parts, "\n"), true
 }
 
 func containsToolUse(raw json.RawMessage) bool {

--- a/internal/tracker/aiplugin/plugin_claude_test.go
+++ b/internal/tracker/aiplugin/plugin_claude_test.go
@@ -1,0 +1,127 @@
+package aiplugin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"traq/internal/storage"
+)
+
+func TestClaudePluginParsesFixtureJSONL(t *testing.T) {
+	root := filepath.Join("testdata", "claude")
+	p := NewClaudePlugin(root)
+	if !p.Available() {
+		t.Fatalf("fixture dir should make plugin available")
+	}
+
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	events, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events (snapshot skipped), got %d", len(events))
+	}
+
+	want := []struct {
+		kind string
+		ts   string
+	}{
+		{"user_prompt", "2026-04-23T10:00:00Z"},
+		{"assistant_turn", "2026-04-23T10:00:05Z"},
+		{"tool_use", "2026-04-23T10:00:10Z"},
+	}
+	for i, w := range want {
+		if events[i].Kind != w.kind {
+			t.Errorf("event[%d].Kind = %q, want %q", i, events[i].Kind, w.kind)
+		}
+		ts, _ := time.Parse(time.RFC3339, w.ts)
+		if !events[i].Timestamp.Equal(ts) {
+			t.Errorf("event[%d].Timestamp = %v, want %v", i, events[i].Timestamp, ts)
+		}
+		if events[i].SessionID != "sess-1" {
+			t.Errorf("event[%d].SessionID = %q", i, events[i].SessionID)
+		}
+		if events[i].ProjectDir != "/home/u/repo" {
+			t.Errorf("event[%d].ProjectDir = %q", i, events[i].ProjectDir)
+		}
+		if events[i].Tool != "claude" {
+			t.Errorf("event[%d].Tool = %q", i, events[i].Tool)
+		}
+	}
+}
+
+func TestClaudePluginResumesFromSourceOffset(t *testing.T) {
+	root := filepath.Join("testdata", "claude")
+	p := NewClaudePlugin(root)
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	first, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) == 0 {
+		t.Fatal("expected events on first poll")
+	}
+	persistOffsetForTest(t, store, first)
+
+	second, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("expected 0 new events on repeat poll, got %d", len(second))
+	}
+}
+
+func persistOffsetForTest(t *testing.T, store *storage.Store, events []AIEvent) {
+	t.Helper()
+	last := events[len(events)-1]
+	sess := &storage.AISession{
+		ID:           last.SessionID,
+		Tool:         last.Tool,
+		ProjectDir:   last.ProjectDir,
+		FilePath:     last.FilePath,
+		StartedAt:    events[0].Timestamp.Unix(),
+		LastEventAt:  last.Timestamp.Unix(),
+		EventCount:   len(events),
+		SourceOffset: last.Offset,
+	}
+	if err := store.UpsertAISession(sess); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClaudePluginSkipsCorruptLines(t *testing.T) {
+	dir := t.TempDir()
+	projDir := filepath.Join(dir, "-tmp-proj")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(projDir, "sess-2.jsonl")
+	content := `{"type":"user","sessionId":"s","cwd":"/t","timestamp":"2026-04-23T10:00:00Z","message":{"role":"user","content":"a"}}
+NOT_JSON_GARBAGE
+{"type":"assistant","sessionId":"s","cwd":"/t","timestamp":"2026-04-23T10:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"b"}]}}
+`
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewClaudePlugin(dir)
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	events, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatalf("poll returned error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 valid events (garbage skipped), got %d", len(events))
+	}
+}

--- a/internal/tracker/aiplugin/plugin_claude_test.go
+++ b/internal/tracker/aiplugin/plugin_claude_test.go
@@ -125,3 +125,51 @@ NOT_JSON_GARBAGE
 		t.Fatalf("expected 2 valid events (garbage skipped), got %d", len(events))
 	}
 }
+
+func TestClaudePluginDropsPromptContentByDefault(t *testing.T) {
+	root := filepath.Join("testdata", "claude")
+	p := NewClaudePlugin(root) // storePromptContent defaults to false
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	events, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	var userPrompts int
+	for _, e := range events {
+		if e.Kind != "user_prompt" {
+			continue
+		}
+		userPrompts++
+		if e.Content != "" {
+			t.Errorf("default-off plugin leaked prompt content: %q", e.Content)
+		}
+	}
+	if userPrompts == 0 {
+		t.Fatal("fixture should include at least one user_prompt event")
+	}
+}
+
+func TestClaudePluginIncludesPromptContentWhenOptedIn(t *testing.T) {
+	root := filepath.Join("testdata", "claude")
+	p := NewClaudePlugin(root)
+	p.SetStorePromptContent(true)
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	events, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	var gotAny bool
+	for _, e := range events {
+		if e.Kind == "user_prompt" && e.Content != "" {
+			gotAny = true
+			break
+		}
+	}
+	if !gotAny {
+		t.Fatal("opted-in plugin should populate at least one user_prompt.Content from the fixture")
+	}
+}

--- a/internal/tracker/aiplugin/plugin_opencode.go
+++ b/internal/tracker/aiplugin/plugin_opencode.go
@@ -1,0 +1,75 @@
+package aiplugin
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"traq/internal/storage"
+)
+
+const toolOpenCode = "opencode"
+
+// OpenCodePlugin reads message timestamps from opencode's SQLite database.
+// Opens the DB read-only (immutable=1) so opencode's live process isn't
+// affected. Cursors on MAX(timestamp) — opencode stores ms, we store s.
+type OpenCodePlugin struct {
+	dbPath string
+}
+
+func NewOpenCodePlugin(dbPath string) *OpenCodePlugin {
+	return &OpenCodePlugin{dbPath: dbPath}
+}
+
+func (p *OpenCodePlugin) Name() string { return toolOpenCode }
+
+func (p *OpenCodePlugin) Available() bool {
+	info, err := os.Stat(p.dbPath)
+	return err == nil && !info.IsDir()
+}
+
+func (p *OpenCodePlugin) Poll(ctx context.Context, store *storage.Store) ([]AIEvent, error) {
+	sinceUnix, err := store.GetMaxAIEventTimestamp(toolOpenCode)
+	if err != nil {
+		return nil, err
+	}
+	sinceMs := sinceUnix * 1000
+
+	dsn := "file:" + p.dbPath + "?mode=ro&immutable=1"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT m.session_id, s.directory, m.time_created
+		FROM message m
+		JOIN session s ON s.id = m.session_id
+		WHERE m.time_created > ?
+		ORDER BY m.time_created ASC
+	`, sinceMs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []AIEvent
+	for rows.Next() {
+		var sessionID, directory string
+		var tsMs int64
+		if err := rows.Scan(&sessionID, &directory, &tsMs); err != nil {
+			return nil, err
+		}
+		out = append(out, AIEvent{
+			Tool:       toolOpenCode,
+			SessionID:  sessionID,
+			ProjectDir: directory,
+			Timestamp:  time.Unix(0, tsMs*int64(time.Millisecond)),
+			Kind:       "message",
+		})
+	}
+	return out, rows.Err()
+}

--- a/internal/tracker/aiplugin/plugin_opencode.go
+++ b/internal/tracker/aiplugin/plugin_opencode.go
@@ -16,11 +16,18 @@ const toolOpenCode = "opencode"
 // Opens the DB read-only (immutable=1) so opencode's live process isn't
 // affected. Cursors on MAX(timestamp) — opencode stores ms, we store s.
 type OpenCodePlugin struct {
-	dbPath string
+	dbPath             string
+	storePromptContent bool
 }
 
 func NewOpenCodePlugin(dbPath string) *OpenCodePlugin {
 	return &OpenCodePlugin{dbPath: dbPath}
+}
+
+// SetStorePromptContent enables/disables storage of verbatim user-message
+// text on emitted events. Off by default — see ClaudePlugin.SetStorePromptContent.
+func (p *OpenCodePlugin) SetStorePromptContent(v bool) {
+	p.storePromptContent = v
 }
 
 func (p *OpenCodePlugin) Name() string { return toolOpenCode }
@@ -70,6 +77,9 @@ func (p *OpenCodePlugin) Poll(ctx context.Context, store *storage.Store) ([]AIEv
 		var tsMs int64
 		if err := rows.Scan(&msgID, &sessionID, &directory, &tsMs, &content); err != nil {
 			return nil, err
+		}
+		if !p.storePromptContent {
+			content = ""
 		}
 		out = append(out, AIEvent{
 			Tool:       toolOpenCode,

--- a/internal/tracker/aiplugin/plugin_opencode.go
+++ b/internal/tracker/aiplugin/plugin_opencode.go
@@ -44,11 +44,19 @@ func (p *OpenCodePlugin) Poll(ctx context.Context, store *storage.Store) ([]AIEv
 	}
 	defer db.Close()
 
+	// Select only user-role messages, joining the part table to retrieve
+	// the prompt text. A single user message can have multiple text parts;
+	// we concatenate them (rare in practice, but safe).
 	rows, err := db.QueryContext(ctx, `
-		SELECT m.session_id, s.directory, m.time_created
+		SELECT m.id, m.session_id, s.directory, m.time_created,
+		       COALESCE(group_concat(json_extract(p.data,'$.text'), CHAR(10)), '')
 		FROM message m
 		JOIN session s ON s.id = m.session_id
+		LEFT JOIN part p ON p.message_id = m.id
+		  AND json_extract(p.data,'$.type') = 'text'
 		WHERE m.time_created > ?
+		  AND json_extract(m.data,'$.role') = 'user'
+		GROUP BY m.id
 		ORDER BY m.time_created ASC
 	`, sinceMs)
 	if err != nil {
@@ -58,9 +66,9 @@ func (p *OpenCodePlugin) Poll(ctx context.Context, store *storage.Store) ([]AIEv
 
 	var out []AIEvent
 	for rows.Next() {
-		var sessionID, directory string
+		var msgID, sessionID, directory, content string
 		var tsMs int64
-		if err := rows.Scan(&sessionID, &directory, &tsMs); err != nil {
+		if err := rows.Scan(&msgID, &sessionID, &directory, &tsMs, &content); err != nil {
 			return nil, err
 		}
 		out = append(out, AIEvent{
@@ -68,7 +76,8 @@ func (p *OpenCodePlugin) Poll(ctx context.Context, store *storage.Store) ([]AIEv
 			SessionID:  sessionID,
 			ProjectDir: directory,
 			Timestamp:  time.Unix(0, tsMs*int64(time.Millisecond)),
-			Kind:       "message",
+			Kind:       "user_prompt",
+			Content:    content,
 		})
 	}
 	return out, rows.Err()

--- a/internal/tracker/aiplugin/plugin_opencode_test.go
+++ b/internal/tracker/aiplugin/plugin_opencode_test.go
@@ -36,9 +36,13 @@ func buildOpencodeFixtureDB(t *testing.T) string {
 		VALUES ('ses_abc', 'proj-1', 'slug', '/home/u/repo', 't', '1', 1700000000000, 1700000030000);
 		INSERT INTO message (id, session_id, time_created, time_updated, data)
 		VALUES
-			('m1', 'ses_abc', 1700000010000, 1700000010000, '{}'),
-			('m2', 'ses_abc', 1700000020000, 1700000020000, '{}'),
-			('m3', 'ses_abc', 1700000030000, 1700000030000, '{}');
+			('m1', 'ses_abc', 1700000010000, 1700000010000, '{"role":"user"}'),
+			('m2', 'ses_abc', 1700000020000, 1700000020000, '{"role":"assistant"}'),
+			('m3', 'ses_abc', 1700000030000, 1700000030000, '{"role":"user"}');
+		INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+		VALUES
+			('p1', 'm1', 'ses_abc', 1700000010000, 1700000010000, '{"type":"text","text":"hello world"}'),
+			('p3', 'm3', 'ses_abc', 1700000030000, 1700000030000, '{"type":"text","text":"second prompt"}');
 	`)
 	if err != nil {
 		t.Fatalf("seed: %v", err)
@@ -60,8 +64,8 @@ func TestOpenCodePluginReadsMessages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("poll: %v", err)
 	}
-	if len(events) != 3 {
-		t.Fatalf("expected 3 events, got %d", len(events))
+	if len(events) != 2 {
+		t.Fatalf("expected 2 user events, got %d", len(events))
 	}
 	for _, e := range events {
 		if e.Tool != "opencode" {
@@ -73,9 +77,15 @@ func TestOpenCodePluginReadsMessages(t *testing.T) {
 		if e.ProjectDir != "/home/u/repo" {
 			t.Errorf("ProjectDir=%q", e.ProjectDir)
 		}
-		if e.Kind != "message" {
+		if e.Kind != "user_prompt" {
 			t.Errorf("Kind=%q", e.Kind)
 		}
+	}
+	if events[0].Content != "hello world" {
+		t.Errorf("events[0].Content=%q, want \"hello world\"", events[0].Content)
+	}
+	if events[1].Content != "second prompt" {
+		t.Errorf("events[1].Content=%q, want \"second prompt\"", events[1].Content)
 	}
 }
 
@@ -89,8 +99,8 @@ func TestOpenCodePluginResumesByMaxTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(first) != 3 {
-		t.Fatalf("expected 3, got %d", len(first))
+	if len(first) != 2 {
+		t.Fatalf("expected 2, got %d", len(first))
 	}
 
 	var dbEvents []storage.AIEvent

--- a/internal/tracker/aiplugin/plugin_opencode_test.go
+++ b/internal/tracker/aiplugin/plugin_opencode_test.go
@@ -1,0 +1,122 @@
+package aiplugin
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"traq/internal/storage"
+)
+
+func buildOpencodeFixtureDB(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "opencode.db")
+
+	schemaBytes, err := os.ReadFile(filepath.Join("testdata", "opencode", "schema.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(string(schemaBytes)); err != nil {
+		t.Fatalf("schema exec: %v", err)
+	}
+
+	_, err = db.Exec(`
+		INSERT INTO project (id, worktree, time_created, time_updated, sandboxes)
+		VALUES ('proj-1', '/home/u/repo', 1700000000000, 1700000000000, '[]');
+		INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+		VALUES ('ses_abc', 'proj-1', 'slug', '/home/u/repo', 't', '1', 1700000000000, 1700000030000);
+		INSERT INTO message (id, session_id, time_created, time_updated, data)
+		VALUES
+			('m1', 'ses_abc', 1700000010000, 1700000010000, '{}'),
+			('m2', 'ses_abc', 1700000020000, 1700000020000, '{}'),
+			('m3', 'ses_abc', 1700000030000, 1700000030000, '{}');
+	`)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return dbPath
+}
+
+func TestOpenCodePluginReadsMessages(t *testing.T) {
+	dbPath := buildOpencodeFixtureDB(t)
+	p := NewOpenCodePlugin(dbPath)
+	if !p.Available() {
+		t.Fatal("plugin should be available with fixture DB")
+	}
+
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	events, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+	for _, e := range events {
+		if e.Tool != "opencode" {
+			t.Errorf("Tool=%q", e.Tool)
+		}
+		if e.SessionID != "ses_abc" {
+			t.Errorf("SessionID=%q", e.SessionID)
+		}
+		if e.ProjectDir != "/home/u/repo" {
+			t.Errorf("ProjectDir=%q", e.ProjectDir)
+		}
+		if e.Kind != "message" {
+			t.Errorf("Kind=%q", e.Kind)
+		}
+	}
+}
+
+func TestOpenCodePluginResumesByMaxTimestamp(t *testing.T) {
+	dbPath := buildOpencodeFixtureDB(t)
+	p := NewOpenCodePlugin(dbPath)
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	first, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 3 {
+		t.Fatalf("expected 3, got %d", len(first))
+	}
+
+	var dbEvents []storage.AIEvent
+	for _, e := range first {
+		dbEvents = append(dbEvents, storage.AIEvent{
+			SessionID: e.SessionID, Tool: e.Tool, Kind: e.Kind,
+			Timestamp: e.Timestamp.Unix(), ProjectDir: e.ProjectDir,
+		})
+	}
+	if err := store.UpsertAISession(&storage.AISession{
+		ID: first[0].SessionID, Tool: "opencode",
+		ProjectDir:  first[0].ProjectDir,
+		StartedAt:   first[0].Timestamp.Unix(),
+		LastEventAt: first[len(first)-1].Timestamp.Unix(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertAIEvents(dbEvents); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("expected 0 new events, got %d", len(second))
+	}
+}

--- a/internal/tracker/aiplugin/plugin_opencode_test.go
+++ b/internal/tracker/aiplugin/plugin_opencode_test.go
@@ -53,6 +53,7 @@ func buildOpencodeFixtureDB(t *testing.T) string {
 func TestOpenCodePluginReadsMessages(t *testing.T) {
 	dbPath := buildOpencodeFixtureDB(t)
 	p := NewOpenCodePlugin(dbPath)
+	p.SetStorePromptContent(true) // opt in for content assertions
 	if !p.Available() {
 		t.Fatal("plugin should be available with fixture DB")
 	}
@@ -86,6 +87,29 @@ func TestOpenCodePluginReadsMessages(t *testing.T) {
 	}
 	if events[1].Content != "second prompt" {
 		t.Errorf("events[1].Content=%q, want \"second prompt\"", events[1].Content)
+	}
+}
+
+func TestOpenCodePluginDropsPromptContentByDefault(t *testing.T) {
+	dbPath := buildOpencodeFixtureDB(t)
+	p := NewOpenCodePlugin(dbPath) // default-off
+	store := storage.NewInMemoryTestStore(t)
+	defer store.Close()
+
+	events, err := p.Poll(context.Background(), store)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 user events, got %d", len(events))
+	}
+	for i, e := range events {
+		if e.Kind != "user_prompt" {
+			t.Errorf("event[%d].Kind=%q, want user_prompt", i, e.Kind)
+		}
+		if e.Content != "" {
+			t.Errorf("default-off plugin leaked prompt content: event[%d].Content=%q", i, e.Content)
+		}
 	}
 }
 

--- a/internal/tracker/aiplugin/testdata/claude/-home-u-repo/sess-1.jsonl
+++ b/internal/tracker/aiplugin/testdata/claude/-home-u-repo/sess-1.jsonl
@@ -1,0 +1,4 @@
+{"type":"file-history-snapshot","messageId":"x","snapshot":{},"isSnapshotUpdate":false}
+{"type":"user","sessionId":"sess-1","cwd":"/home/u/repo","timestamp":"2026-04-23T10:00:00.000Z","message":{"role":"user","content":"hello"}}
+{"type":"assistant","sessionId":"sess-1","cwd":"/home/u/repo","timestamp":"2026-04-23T10:00:05.000Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}
+{"type":"assistant","sessionId":"sess-1","cwd":"/home/u/repo","timestamp":"2026-04-23T10:00:10.000Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash"}]}}

--- a/internal/tracker/aiplugin/testdata/opencode/schema.sql
+++ b/internal/tracker/aiplugin/testdata/opencode/schema.sql
@@ -31,3 +31,12 @@ CREATE TABLE message (
 	time_updated integer NOT NULL,
 	data text NOT NULL
 );
+
+CREATE TABLE part (
+	id text PRIMARY KEY,
+	message_id text NOT NULL,
+	session_id text NOT NULL,
+	time_created integer NOT NULL,
+	time_updated integer NOT NULL,
+	data text NOT NULL
+);

--- a/internal/tracker/aiplugin/testdata/opencode/schema.sql
+++ b/internal/tracker/aiplugin/testdata/opencode/schema.sql
@@ -1,0 +1,33 @@
+CREATE TABLE project (
+	id text PRIMARY KEY,
+	worktree text NOT NULL,
+	vcs text,
+	name text,
+	icon_url text,
+	icon_color text,
+	time_created integer NOT NULL,
+	time_updated integer NOT NULL,
+	time_initialized integer,
+	sandboxes text NOT NULL,
+	commands text
+);
+
+CREATE TABLE session (
+	id text PRIMARY KEY,
+	project_id text NOT NULL,
+	parent_id text,
+	slug text NOT NULL,
+	directory text NOT NULL,
+	title text NOT NULL,
+	version text NOT NULL,
+	time_created integer NOT NULL,
+	time_updated integer NOT NULL
+);
+
+CREATE TABLE message (
+	id text PRIMARY KEY,
+	session_id text NOT NULL,
+	time_created integer NOT NULL,
+	time_updated integer NOT NULL,
+	data text NOT NULL
+);

--- a/internal/tracker/daemon.go
+++ b/internal/tracker/daemon.go
@@ -11,6 +11,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"traq/internal/platform"
 	"traq/internal/storage"
+	"traq/internal/tracker/aiplugin"
 )
 
 // DaemonConfig holds configuration for the tracker daemon.
@@ -59,6 +60,7 @@ type Daemon struct {
 	git     *GitTracker
 	files   *FileTracker
 	browser *BrowserTracker
+	ai      *AITracker
 
 	running         bool
 	paused          bool
@@ -95,6 +97,15 @@ func NewDaemon(config *DaemonConfig, store *storage.Store, plat platform.Platfor
 	// BrowserTracker for tracking browser history
 	browser := NewBrowserTracker(plat, store, config.DataDir)
 
+	// AITracker polls Claude Code and opencode session data from the user's
+	// home dir. If HOME isn't set, both plugins' Available() return false
+	// and ai.Poll() becomes a no-op.
+	home, _ := os.UserHomeDir()
+	ai := NewAITracker(store, []aiplugin.AIPlugin{
+		aiplugin.NewClaudePlugin(filepath.Join(home, ".claude", "projects")),
+		aiplugin.NewOpenCodePlugin(filepath.Join(home, ".local", "share", "opencode", "opencode.db")),
+	})
+
 	d := &Daemon{
 		config:            config,
 		store:             store,
@@ -107,6 +118,7 @@ func NewDaemon(config *DaemonConfig, store *storage.Store, plat platform.Platfor
 		git:               git,
 		files:             files,
 		browser:           browser,
+		ai:                ai,
 		stopCh:            make(chan struct{}),
 		afkRestartMinutes: 10, // Default: restart after 10 min AFK with pending update
 	}
@@ -377,6 +389,12 @@ func (d *Daemon) tick() {
 
 	// Poll browser history for new visits
 	d.browser.Poll(session.ID)
+
+	// Poll AI plugins (Claude Code, opencode). Independent of the current
+	// Traq session — AI events have no session FK.
+	if d.ai != nil {
+		_ = d.ai.Poll()
+	}
 }
 
 // checkAutoUpdate checks if we should auto-restart to apply a pending update.

--- a/internal/tracker/daemon.go
+++ b/internal/tracker/daemon.go
@@ -28,6 +28,13 @@ type DaemonConfig struct {
 	// AIStorePromptContent opts into verbatim user-prompt storage in the
 	// AI coding data source. Default false. See AITrackingConfig.
 	AIStorePromptContent bool
+
+	// AI tracking master + per-tool enable flags. Defaults true so an empty
+	// DaemonConfig keeps the previous "always on" behavior; production
+	// callers populate these from AITrackingConfig.
+	AITrackingEnabled bool
+	AIClaudeEnabled   bool
+	AIOpenCodeEnabled bool
 }
 
 // DefaultDaemonConfig returns a default configuration.
@@ -41,6 +48,9 @@ func DefaultDaemonConfig(dataDir string) *DaemonConfig {
 		DataDir:            dataDir,
 		MonitorMode:        "active_window",
 		MonitorIndex:       0,
+		AITrackingEnabled:  true,
+		AIClaudeEnabled:    true,
+		AIOpenCodeEnabled:  true,
 	}
 }
 
@@ -110,6 +120,9 @@ func NewDaemon(config *DaemonConfig, store *storage.Store, plat platform.Platfor
 	opencodePlugin := aiplugin.NewOpenCodePlugin(filepath.Join(home, ".local", "share", "opencode", "opencode.db"))
 	opencodePlugin.SetStorePromptContent(config.AIStorePromptContent)
 	ai := NewAITracker(store, []aiplugin.AIPlugin{claudePlugin, opencodePlugin})
+	ai.SetEnabled(config.AITrackingEnabled)
+	ai.SetToolEnabled("claude", config.AIClaudeEnabled)
+	ai.SetToolEnabled("opencode", config.AIOpenCodeEnabled)
 
 	d := &Daemon{
 		config:            config,
@@ -539,6 +552,11 @@ func (d *Daemon) UpdateConfig(config *DaemonConfig) {
 	d.afk.SetTimeout(config.AFKTimeout)
 	if config.ResumeWindow > 0 {
 		d.session.SetResumeWindow(config.ResumeWindow)
+	}
+	if d.ai != nil {
+		d.ai.SetEnabled(config.AITrackingEnabled)
+		d.ai.SetToolEnabled("claude", config.AIClaudeEnabled)
+		d.ai.SetToolEnabled("opencode", config.AIOpenCodeEnabled)
 	}
 }
 

--- a/internal/tracker/daemon.go
+++ b/internal/tracker/daemon.go
@@ -560,6 +560,19 @@ func (d *Daemon) UpdateConfig(config *DaemonConfig) {
 	}
 }
 
+// SetAITrackingFlags forwards the master + per-tool enable toggles to the
+// AITracker so a Settings change takes effect on the next poll tick.
+// storePromptContent is intentionally not exposed here — it requires an
+// app restart so the user has an explicit boundary for the privacy change.
+func (d *Daemon) SetAITrackingFlags(enabled, claude, opencode bool) {
+	if d.ai == nil {
+		return
+	}
+	d.ai.SetEnabled(enabled)
+	d.ai.SetToolEnabled("claude", claude)
+	d.ai.SetToolEnabled("opencode", opencode)
+}
+
 // SetUpdateCallbacks sets the callbacks for auto-update support.
 // onReady is called to check if an update is pending (returns true if ready to apply).
 // onApply is called to apply the update and restart the app.

--- a/internal/tracker/daemon.go
+++ b/internal/tracker/daemon.go
@@ -24,6 +24,10 @@ type DaemonConfig struct {
 	DataDir            string
 	MonitorMode        string // "active_window", "primary", "specific"
 	MonitorIndex       int    // Only used when MonitorMode is "specific"
+
+	// AIStorePromptContent opts into verbatim user-prompt storage in the
+	// AI coding data source. Default false. See AITrackingConfig.
+	AIStorePromptContent bool
 }
 
 // DefaultDaemonConfig returns a default configuration.
@@ -101,10 +105,11 @@ func NewDaemon(config *DaemonConfig, store *storage.Store, plat platform.Platfor
 	// home dir. If HOME isn't set, both plugins' Available() return false
 	// and ai.Poll() becomes a no-op.
 	home, _ := os.UserHomeDir()
-	ai := NewAITracker(store, []aiplugin.AIPlugin{
-		aiplugin.NewClaudePlugin(filepath.Join(home, ".claude", "projects")),
-		aiplugin.NewOpenCodePlugin(filepath.Join(home, ".local", "share", "opencode", "opencode.db")),
-	})
+	claudePlugin := aiplugin.NewClaudePlugin(filepath.Join(home, ".claude", "projects"))
+	claudePlugin.SetStorePromptContent(config.AIStorePromptContent)
+	opencodePlugin := aiplugin.NewOpenCodePlugin(filepath.Join(home, ".local", "share", "opencode", "opencode.db"))
+	opencodePlugin.SetStorePromptContent(config.AIStorePromptContent)
+	ai := NewAITracker(store, []aiplugin.AIPlugin{claudePlugin, opencodePlugin})
 
 	d := &Daemon{
 		config:            config,

--- a/internal/tracker/plugin_log.go
+++ b/internal/tracker/plugin_log.go
@@ -1,0 +1,123 @@
+package tracker
+
+import (
+	"bufio"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"traq/internal/storage"
+)
+
+var errUnsupportedVersion = errors.New("unsupported plugin log version")
+
+const pluginLogVersion = "1"
+
+// parsePluginLogLine parses a single TSV line from the Traq plugin log.
+// Format: <version>\t<ts>\t<exit>\t<duration_ms>\t<cwd>\t<tmux>\t<host>\t<shell>\t<command>
+func parsePluginLogLine(line string) (*storage.ShellCommand, error) {
+	parts := strings.SplitN(line, "\t", 9)
+	if len(parts) != 9 {
+		return nil, fmt.Errorf("expected 9 TSV fields, got %d", len(parts))
+	}
+	if parts[0] != pluginLogVersion {
+		return nil, errUnsupportedVersion
+	}
+
+	ts, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parse timestamp: %w", err)
+	}
+
+	cmd := &storage.ShellCommand{
+		Timestamp: ts,
+		ShellType: parts[7],
+		Command:   unescapeCommand(parts[8]),
+	}
+
+	if exitCode, err := strconv.ParseInt(parts[2], 10, 64); err == nil {
+		cmd.ExitCode = sql.NullInt64{Int64: exitCode, Valid: true}
+	}
+	if durMs, err := strconv.ParseInt(parts[3], 10, 64); err == nil {
+		cmd.DurationSeconds = sql.NullFloat64{Float64: float64(durMs) / 1000.0, Valid: true}
+	}
+	if parts[4] != "" && parts[4] != "-" {
+		cmd.WorkingDirectory = sql.NullString{String: parts[4], Valid: true}
+	}
+	if parts[5] != "" && parts[5] != "-" {
+		cmd.TmuxContext = sql.NullString{String: parts[5], Valid: true}
+	}
+	if parts[6] != "" && parts[6] != "-" {
+		cmd.Hostname = sql.NullString{String: parts[6], Valid: true}
+	}
+	return cmd, nil
+}
+
+func unescapeCommand(s string) string {
+	// Reverse the plugin's escaping: \t -> tab, \n -> newline, \\ -> \.
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case 't':
+				b.WriteByte('\t')
+				i += 2
+				continue
+			case 'n':
+				b.WriteByte('\n')
+				i += 2
+				continue
+			case '\\':
+				b.WriteByte('\\')
+				i += 2
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// readAndTruncatePluginLog reads all commands from the plugin log, then truncates the file.
+// Returns (nil, nil) if the file does not exist.
+func readAndTruncatePluginLog(path string) ([]*storage.ShellCommand, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0600)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open plugin log: %w", err)
+	}
+	defer f.Close()
+
+	var commands []*storage.ShellCommand
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		cmd, err := parsePluginLogLine(line)
+		if err != nil {
+			// Skip malformed or unsupported lines silently; corrupt lines
+			// should never block ingestion of valid ones.
+			continue
+		}
+		commands = append(commands, cmd)
+	}
+	if err := scanner.Err(); err != nil {
+		return commands, fmt.Errorf("scan plugin log: %w", err)
+	}
+
+	if err := f.Truncate(0); err != nil {
+		return commands, fmt.Errorf("truncate plugin log: %w", err)
+	}
+	return commands, nil
+}

--- a/internal/tracker/plugin_log_test.go
+++ b/internal/tracker/plugin_log_test.go
@@ -1,0 +1,107 @@
+package tracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParsePluginLogLine_AllFields(t *testing.T) {
+	line := "1\t1745000000\t0\t123\t/home/jl/repos/traq\tmain:1\thost\tbash\tgit push origin master"
+	cmd, err := parsePluginLogLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.Timestamp != 1745000000 {
+		t.Errorf("Timestamp: got %d, want 1745000000", cmd.Timestamp)
+	}
+	if cmd.Command != "git push origin master" {
+		t.Errorf("Command: got %q", cmd.Command)
+	}
+	if cmd.ShellType != "bash" {
+		t.Errorf("ShellType: got %q", cmd.ShellType)
+	}
+	if !cmd.ExitCode.Valid || cmd.ExitCode.Int64 != 0 {
+		t.Errorf("ExitCode: got %+v", cmd.ExitCode)
+	}
+	if !cmd.DurationSeconds.Valid || cmd.DurationSeconds.Float64 != 0.123 {
+		t.Errorf("DurationSeconds: got %+v", cmd.DurationSeconds)
+	}
+	if !cmd.WorkingDirectory.Valid || cmd.WorkingDirectory.String != "/home/jl/repos/traq" {
+		t.Errorf("WorkingDirectory: got %+v", cmd.WorkingDirectory)
+	}
+	if !cmd.TmuxContext.Valid || cmd.TmuxContext.String != "main:1" {
+		t.Errorf("TmuxContext: got %+v", cmd.TmuxContext)
+	}
+	if !cmd.Hostname.Valid || cmd.Hostname.String != "host" {
+		t.Errorf("Hostname: got %+v", cmd.Hostname)
+	}
+}
+
+func TestParsePluginLogLine_NoTmux(t *testing.T) {
+	line := "1\t1745000000\t0\t50\t/tmp\t-\thost\tzsh\tls"
+	cmd, err := parsePluginLogLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.TmuxContext.Valid {
+		t.Errorf("TmuxContext should be invalid for '-', got %+v", cmd.TmuxContext)
+	}
+}
+
+func TestParsePluginLogLine_EscapedCommand(t *testing.T) {
+	line := "1\t1745000000\t0\t0\t/tmp\t-\thost\tbash\techo line1\\nline2"
+	cmd, err := parsePluginLogLine(line)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd.Command != "echo line1\nline2" {
+		t.Errorf("Command unescape failed: got %q", cmd.Command)
+	}
+}
+
+func TestParsePluginLogLine_UnknownVersion(t *testing.T) {
+	line := "99\t1745000000\t0\t0\t/\t-\th\tbash\tx"
+	_, err := parsePluginLogLine(line)
+	if err != errUnsupportedVersion {
+		t.Errorf("expected errUnsupportedVersion, got %v", err)
+	}
+}
+
+func TestIngestPluginLog_TruncatesAfterRead(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "history.log")
+	content := "1\t1745000000\t0\t0\t/\t-\th\tbash\tls\n" +
+		"1\t1745000001\t0\t0\t/\t-\th\tbash\tpwd\n"
+	if err := os.WriteFile(logPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmds, err := readAndTruncatePluginLog(logPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cmds) != 2 {
+		t.Fatalf("got %d commands, want 2", len(cmds))
+	}
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("log file should be truncated, size=%d", info.Size())
+	}
+}
+
+func TestIngestPluginLog_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "missing.log")
+	cmds, err := readAndTruncatePluginLog(logPath)
+	if err != nil {
+		t.Fatalf("missing file should not error, got %v", err)
+	}
+	if len(cmds) != 0 {
+		t.Errorf("expected 0 commands, got %d", len(cmds))
+	}
+}

--- a/internal/tracker/shell.go
+++ b/internal/tracker/shell.go
@@ -20,6 +20,7 @@ import (
 type ShellTracker struct {
 	platform          platform.Platform
 	store             *storage.Store
+	dataDir           string
 	checkpointFile    string
 	excludePatterns   []*regexp.Regexp
 	shellTypeOverride string // If set, overrides platform detection ("auto" means use platform)
@@ -36,6 +37,7 @@ func NewShellTracker(p platform.Platform, store *storage.Store, dataDir string) 
 	return &ShellTracker{
 		platform:       p,
 		store:          store,
+		dataDir:        dataDir,
 		checkpointFile: filepath.Join(dataDir, "shell_checkpoint.json"),
 		excludePatterns: []*regexp.Regexp{
 			regexp.MustCompile(`(?i)(password|passwd|secret|token|key=|api_key|apikey|auth)`),
@@ -113,9 +115,12 @@ func (t *ShellTracker) GetHistoryPathOverride() string {
 	return t.historyPathOverride
 }
 
-// pluginLogPath returns the path to the Traq shell plugin log.
+// pluginLogPath returns the path to the Traq shell plugin log. The directory
+// layout must stay in sync with ShellSetupService.shellDir — both derive
+// `<dataDir>/shell/...` from the same dataDir so the reader and the writer
+// can't drift apart.
 func (t *ShellTracker) pluginLogPath() string {
-	return filepath.Join(filepath.Dir(t.checkpointFile), "shell", "history.log")
+	return filepath.Join(t.dataDir, "shell", "history.log")
 }
 
 // Poll reads new commands from history and saves them.
@@ -134,8 +139,13 @@ func (t *ShellTracker) Poll(sessionID int64) ([]*storage.ShellCommand, error) {
 		nativeCmds = nil
 	}
 
-	// Merge and persist.
-	all := append(pluginCmds, nativeCmds...)
+	// Merge and persist. Allocate a fresh slice rather than append-in-place
+	// so we don't mutate pluginCmds' backing array — a caller inspecting
+	// the returned slices from readAndTruncatePluginLog / pollNativeHistory
+	// should see them unmodified.
+	all := make([]*storage.ShellCommand, 0, len(pluginCmds)+len(nativeCmds))
+	all = append(all, pluginCmds...)
+	all = append(all, nativeCmds...)
 
 	var saved []*storage.ShellCommand
 	for _, cmd := range all {

--- a/internal/tracker/shell.go
+++ b/internal/tracker/shell.go
@@ -113,46 +113,39 @@ func (t *ShellTracker) GetHistoryPathOverride() string {
 	return t.historyPathOverride
 }
 
+// pluginLogPath returns the path to the Traq shell plugin log.
+func (t *ShellTracker) pluginLogPath() string {
+	return filepath.Join(filepath.Dir(t.checkpointFile), "shell", "history.log")
+}
+
 // Poll reads new commands from history and saves them.
 func (t *ShellTracker) Poll(sessionID int64) ([]*storage.ShellCommand, error) {
-	// Use custom history path if set, otherwise use platform default
-	histPath := t.historyPathOverride
-	if histPath == "" {
-		histPath = t.platform.GetShellHistoryPath()
-	}
-	if histPath == "" {
-		return nil, nil
-	}
-
-	shellType := t.GetShellType()
-
-	// Load checkpoint
-	checkpoint, err := t.loadCheckpoint()
+	// 1. Try the Traq plugin log first (richer format, real-time).
+	pluginCmds, err := readAndTruncatePluginLog(t.pluginLogPath())
 	if err != nil {
-		checkpoint = &ShellCheckpoint{Offsets: make(map[string]int64)}
+		return nil, fmt.Errorf("plugin log: %w", err)
 	}
 
-	offset := checkpoint.Offsets[histPath]
-
-	// Parse history
-	commands, newOffset, err := t.parseHistory(histPath, shellType, offset)
+	// 2. Also read from the native history file (fallback + commands from shells
+	//    without the plugin installed).
+	nativeCmds, newOffset, err := t.pollNativeHistory()
 	if err != nil {
-		return nil, err
+		// Non-fatal: continue with plugin commands only.
+		nativeCmds = nil
 	}
 
-	// Filter and save commands
+	// Merge and persist.
+	all := append(pluginCmds, nativeCmds...)
+
 	var saved []*storage.ShellCommand
-	for _, cmd := range commands {
+	for _, cmd := range all {
 		if t.shouldExclude(cmd.Command) {
 			continue
 		}
-
-		// Check if already exists
 		exists, err := t.store.CommandExists(cmd.Timestamp, cmd.Command)
 		if err != nil || exists {
 			continue
 		}
-
 		cmd.SessionID = sql.NullInt64{Int64: sessionID, Valid: sessionID > 0}
 		id, err := t.store.SaveShellCommand(cmd)
 		if err != nil {
@@ -162,11 +155,38 @@ func (t *ShellTracker) Poll(sessionID int64) ([]*storage.ShellCommand, error) {
 		saved = append(saved, cmd)
 	}
 
-	// Update checkpoint
-	checkpoint.Offsets[histPath] = newOffset
-	t.saveCheckpoint(checkpoint)
-
+	// Advance native-history checkpoint only if we actually read that source.
+	if newOffset >= 0 {
+		checkpoint, err := t.loadCheckpoint()
+		if err != nil {
+			checkpoint = &ShellCheckpoint{Offsets: make(map[string]int64)}
+		}
+		checkpoint.Offsets[t.GetHistoryPath()] = newOffset
+		t.saveCheckpoint(checkpoint)
+	}
 	return saved, nil
+}
+
+// pollNativeHistory reads the native shell-history file. Returns
+// (nil, -1, nil) if no native history path is configured.
+func (t *ShellTracker) pollNativeHistory() ([]*storage.ShellCommand, int64, error) {
+	histPath := t.GetHistoryPath()
+	if histPath == "" {
+		return nil, -1, nil
+	}
+	shellType := t.GetShellType()
+
+	checkpoint, err := t.loadCheckpoint()
+	if err != nil {
+		checkpoint = &ShellCheckpoint{Offsets: make(map[string]int64)}
+	}
+	offset := checkpoint.Offsets[histPath]
+
+	commands, newOffset, err := t.parseHistory(histPath, shellType, offset)
+	if err != nil {
+		return nil, -1, err
+	}
+	return commands, newOffset, nil
 }
 
 func (t *ShellTracker) parseHistory(path, shellType string, offset int64) ([]*storage.ShellCommand, int64, error) {

--- a/internal/tracker/shell_integration_test.go
+++ b/internal/tracker/shell_integration_test.go
@@ -1,0 +1,70 @@
+package tracker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestShellTracker_PollReadsPluginLogWhenPresent(t *testing.T) {
+	store, tmpDir := setupShellTestDB(t)
+	defer store.Close()
+	defer os.RemoveAll(tmpDir)
+
+	pluginDir := filepath.Join(tmpDir, "shell")
+	if err := os.MkdirAll(pluginDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(pluginDir, "history.log")
+	content := "1\t1745000000\t0\t10\t/tmp\tmain:1\thost\tbash\tls -la\n"
+	if err := os.WriteFile(logPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	plat := &mockPlatformShell{shellType: "bash", historyPath: "/nonexistent/history_file"}
+	tracker := NewShellTracker(plat, store, tmpDir)
+
+	saved, err := tracker.Poll(0)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(saved))
+	}
+	if saved[0].Command != "ls -la" {
+		t.Errorf("Command: got %q", saved[0].Command)
+	}
+	if !saved[0].TmuxContext.Valid || saved[0].TmuxContext.String != "main:1" {
+		t.Errorf("TmuxContext: got %+v", saved[0].TmuxContext)
+	}
+	info, _ := os.Stat(logPath)
+	if info.Size() != 0 {
+		t.Errorf("log not truncated")
+	}
+}
+
+func TestShellTracker_PollFallsBackToNativeHistory(t *testing.T) {
+	store, tmpDir := setupShellTestDB(t)
+	defer store.Close()
+	defer os.RemoveAll(tmpDir)
+
+	histFile := filepath.Join(tmpDir, ".bash_history")
+	content := "#1745000000\nvim foo.go\n"
+	if err := os.WriteFile(histFile, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	plat := &mockPlatformShell{shellType: "bash", historyPath: histFile}
+	tracker := NewShellTracker(plat, store, tmpDir)
+
+	saved, err := tracker.Poll(0)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(saved) != 1 || saved[0].Command != "vim foo.go" {
+		t.Fatalf("unexpected saved: %+v", saved)
+	}
+	if saved[0].TmuxContext.Valid {
+		t.Errorf("native history should not populate tmux_context")
+	}
+}

--- a/internal/tracker/shellplugin/embed.go
+++ b/internal/tracker/shellplugin/embed.go
@@ -1,0 +1,55 @@
+// Package shellplugin provides embedded shell plugin scripts.
+package shellplugin
+
+import (
+	"embed"
+	"errors"
+)
+
+//go:embed embed/*
+var files embed.FS
+
+// ShellKind enumerates supported plugin shells.
+type ShellKind string
+
+const (
+	Bash       ShellKind = "bash"
+	Zsh        ShellKind = "zsh"
+	Fish       ShellKind = "fish"
+	PowerShell ShellKind = "powershell"
+)
+
+var errUnknownShell = errors.New("unknown shell kind")
+
+// Filename returns the on-disk filename used when installing the plugin.
+func Filename(kind ShellKind) string {
+	switch kind {
+	case Bash:
+		return "plugin.bash"
+	case Zsh:
+		return "plugin.zsh"
+	case Fish:
+		return "plugin.fish"
+	case PowerShell:
+		return "plugin.ps1"
+	}
+	return ""
+}
+
+// Script returns the plugin contents for the given shell.
+func Script(kind ShellKind) ([]byte, error) {
+	var p string
+	switch kind {
+	case Bash:
+		p = "embed/traq.bash"
+	case Zsh:
+		p = "embed/traq.zsh"
+	case Fish:
+		p = "embed/traq.fish"
+	case PowerShell:
+		p = "embed/Traq.ps1"
+	default:
+		return nil, errUnknownShell
+	}
+	return files.ReadFile(p)
+}

--- a/internal/tracker/shellplugin/embed/Traq.ps1
+++ b/internal/tracker/shellplugin/embed/Traq.ps1
@@ -1,1 +1,79 @@
-# traq PowerShell plugin — placeholder
+# Traq shell integration for PowerShell.
+
+if ($global:__TRAQ_LOADED) { return }
+$global:__TRAQ_LOADED = $true
+
+$script:__traq_dir = if ($env:XDG_DATA_HOME) {
+    Join-Path $env:XDG_DATA_HOME 'traq\shell'
+} else {
+    Join-Path $env:APPDATA 'traq\shell'
+}
+$script:__traq_marker  = Join-Path $__traq_dir 'enabled'
+$script:__traq_log     = Join-Path $__traq_dir 'history.log'
+$script:__traq_overflow = Join-Path $__traq_dir 'overflowed'
+$script:__traq_max_bytes = 10485760
+$script:__traq_start = 0
+$script:__traq_cmd = $null
+
+function __Traq-PreInvoke {
+    param($Command)
+    $script:__traq_cmd = $Command
+    $script:__traq_start = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+}
+
+function __Traq-Escape([string]$s) {
+    $s = $s -replace '\\', '\\'
+    $s = $s -replace "`t", '\t'
+    $s = $s -replace "`n", '\n'
+    if ($s.Length -gt 4000) { $s = $s.Substring(0, 4000) + '…' }
+    return $s
+}
+
+function __Traq-Record {
+    param([int]$ExitCode)
+    if (-not (Test-Path $script:__traq_marker)) { return }
+
+    if (Test-Path $script:__traq_log) {
+        $size = (Get-Item $script:__traq_log).Length
+        if ($size -gt $script:__traq_max_bytes) {
+            New-Item -Path $script:__traq_overflow -ItemType File -Force | Out-Null
+            return
+        }
+    }
+
+    $end = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+    $durationMs = if ($script:__traq_start) { $end - $script:__traq_start } else { 0 }
+
+    $tmuxCtx = '-'
+    if ($env:TMUX) {
+        $s = (tmux display-message -p '#S') 2>$null
+        $w = (tmux display-message -p '#I') 2>$null
+        if ($s -and $w) { $tmuxCtx = "${s}:${w}" }
+    }
+
+    $hostName = try { [System.Net.Dns]::GetHostName() } catch { '-' }
+    $cwd = (Get-Location).Path
+    $ts = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $cmdEscaped = __Traq-Escape $script:__traq_cmd
+
+    if (-not (Test-Path $script:__traq_dir)) {
+        New-Item -Path $script:__traq_dir -ItemType Directory -Force | Out-Null
+    }
+    $line = "1`t${ts}`t${ExitCode}`t${durationMs}`t${cwd}`t${tmuxCtx}`t${hostName}`tpowershell`t${cmdEscaped}"
+    Add-Content -Path $script:__traq_log -Value $line -Encoding UTF8
+}
+
+# Hook via prompt function override (simplest cross-version approach).
+$__traq_prompt_original = (Get-Item function:prompt).ScriptBlock
+function global:prompt {
+    $ec = $LASTEXITCODE
+    if ($script:__traq_cmd) {
+        __Traq-Record -ExitCode ([int]($ec -is [int] ? $ec : 0))
+        $script:__traq_cmd = $null
+    }
+    $hist = Get-History -Count 1
+    if ($hist) {
+        __Traq-PreInvoke $hist.CommandLine
+    }
+    & $__traq_prompt_original
+}

--- a/internal/tracker/shellplugin/embed/Traq.ps1
+++ b/internal/tracker/shellplugin/embed/Traq.ps1
@@ -1,0 +1,1 @@
+# traq PowerShell plugin — placeholder

--- a/internal/tracker/shellplugin/embed/traq.bash
+++ b/internal/tracker/shellplugin/embed/traq.bash
@@ -10,13 +10,15 @@ __traq_log="$__traq_dir/history.log"
 __traq_overflow="$__traq_dir/overflowed"
 __traq_max_bytes=10485760  # 10 MiB
 
-# Capture command start time via PS0 (fires before each command runs).
-# EPOCHREALTIME is bash 5+; fall back to date for older bash.
-if [[ -n "${EPOCHREALTIME:-}" ]]; then
-    PS0='${__traq_start:=$EPOCHREALTIME}'
-else
-    PS0='${__traq_start:=$(date +%s)}'
-fi
+# Capture command start time via DEBUG trap (fires before each command).
+# Using PS0 would print the timestamp to the terminal; DEBUG is silent.
+# functrace is off by default, so DEBUG does not fire inside __traq_hook.
+__traq_preexec() {
+    [[ -n "${COMP_LINE:-}" ]] && return
+    [[ "$BASH_COMMAND" == "__traq_hook" ]] && return
+    __traq_start="${EPOCHREALTIME:-$(date +%s)}"
+}
+trap '__traq_preexec' DEBUG
 
 __traq_escape() {
     local s="$1"

--- a/internal/tracker/shellplugin/embed/traq.bash
+++ b/internal/tracker/shellplugin/embed/traq.bash
@@ -88,12 +88,13 @@ __traq_hook() {
         fi
     fi
 
+    # Format: session:window_idx/window_name:pane_idx/pane_cmd
+    # e.g. "main:2/logs:1/vim" or "0:0/bash:0/bash"
     local tmux_ctx="-"
     if [[ -n "${TMUX:-}" ]]; then
-        local session window
-        session=$(tmux display-message -p '#S' 2>/dev/null)
-        window=$(tmux display-message -p '#I' 2>/dev/null)
-        [[ -n "$session" && -n "$window" ]] && tmux_ctx="${session}:${window}"
+        local ctx
+        ctx=$(tmux display-message -p '#S:#I/#W:#P/#{pane_current_command}' 2>/dev/null)
+        [[ -n "$ctx" ]] && tmux_ctx="$ctx"
     fi
 
     local hostname

--- a/internal/tracker/shellplugin/embed/traq.bash
+++ b/internal/tracker/shellplugin/embed/traq.bash
@@ -33,6 +33,9 @@ __traq_escape() {
 
 __traq_hook() {
     local exit_code=$?
+    # Skip if no DEBUG preexec fired (e.g., first prompt of a new shell).
+    # Without this, history 1 returns stale entries from ~/.bash_history.
+    [[ -z "${__traq_start:-}" ]] && return
     [[ -f "$__traq_marker" ]] || { unset __traq_start; return; }
 
     # Overflow check

--- a/internal/tracker/shellplugin/embed/traq.bash
+++ b/internal/tracker/shellplugin/embed/traq.bash
@@ -1,0 +1,92 @@
+# Traq shell integration for bash. Managed by Traq.
+# Do not edit in place — reinstall via the Traq UI to update.
+
+[[ -n "${__TRAQ_LOADED:-}" ]] && return 0
+__TRAQ_LOADED=1
+
+__traq_dir="${XDG_DATA_HOME:-$HOME/.local/share}/traq/shell"
+__traq_marker="$__traq_dir/enabled"
+__traq_log="$__traq_dir/history.log"
+__traq_overflow="$__traq_dir/overflowed"
+__traq_max_bytes=10485760  # 10 MiB
+
+# Capture command start time via PS0 (fires before each command runs).
+# EPOCHREALTIME is bash 5+; fall back to date for older bash.
+if [[ -n "${EPOCHREALTIME:-}" ]]; then
+    PS0='${__traq_start:=$EPOCHREALTIME}'
+else
+    PS0='${__traq_start:=$(date +%s)}'
+fi
+
+__traq_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\n'/\\n}"
+    if [[ ${#s} -gt 4000 ]]; then
+        s="${s:0:4000}…"
+    fi
+    printf '%s' "$s"
+}
+
+__traq_hook() {
+    local exit_code=$?
+    [[ -f "$__traq_marker" ]] || { unset __traq_start; return; }
+
+    # Overflow check
+    if [[ -f "$__traq_log" ]]; then
+        local size
+        size=$(wc -c < "$__traq_log" 2>/dev/null | tr -d ' ')
+        if [[ -n "$size" && "$size" -gt "$__traq_max_bytes" ]]; then
+            : > "$__traq_overflow"
+            unset __traq_start
+            return
+        fi
+    fi
+
+    # Last command via HISTCMD-based lookup
+    local cmd
+    cmd=$(HISTTIMEFORMAT= builtin history 1 2>/dev/null | sed 's/^ *[0-9]* *//')
+    [[ -z "$cmd" ]] && { unset __traq_start; return; }
+
+    local ts
+    ts=$(date +%s)
+
+    local duration_ms=0
+    if [[ -n "${__traq_start:-}" ]]; then
+        local end now
+        if [[ -n "${EPOCHREALTIME:-}" ]]; then
+            end="$EPOCHREALTIME"
+            duration_ms=$(awk -v s="$__traq_start" -v e="$end" 'BEGIN{printf "%.0f", (e - s) * 1000}')
+        else
+            now=$(date +%s)
+            duration_ms=$(( (now - __traq_start) * 1000 ))
+        fi
+    fi
+
+    local tmux_ctx="-"
+    if [[ -n "${TMUX:-}" ]]; then
+        local session window
+        session=$(tmux display-message -p '#S' 2>/dev/null)
+        window=$(tmux display-message -p '#I' 2>/dev/null)
+        [[ -n "$session" && -n "$window" ]] && tmux_ctx="${session}:${window}"
+    fi
+
+    local hostname
+    hostname=$(hostname -s 2>/dev/null || echo "-")
+
+    mkdir -p "$__traq_dir" 2>/dev/null
+    printf '1\t%s\t%s\t%s\t%s\t%s\t%s\tbash\t%s\n' \
+        "$ts" "$exit_code" "$duration_ms" "$PWD" "$tmux_ctx" "$hostname" \
+        "$(__traq_escape "$cmd")" \
+        >> "$__traq_log"
+
+    unset __traq_start
+}
+
+# Prepend to PROMPT_COMMAND so we run first (and don't clobber existing hooks).
+case "${PROMPT_COMMAND:-}" in
+    *"__traq_hook"*) ;;
+    "") PROMPT_COMMAND="__traq_hook" ;;
+    *) PROMPT_COMMAND="__traq_hook; $PROMPT_COMMAND" ;;
+esac

--- a/internal/tracker/shellplugin/embed/traq.bash
+++ b/internal/tracker/shellplugin/embed/traq.bash
@@ -10,9 +10,13 @@ __traq_log="$__traq_dir/history.log"
 __traq_overflow="$__traq_dir/overflowed"
 __traq_max_bytes=10485760  # 10 MiB
 
+# Baseline history number. Set lazily on the first hook call because
+# bash loads $HISTFILE into memory *after* rc files run, so snapshotting
+# here would see an empty history and still log the stale last entry.
+__traq_last_histnum=""
+
 # Capture command start time via DEBUG trap (fires before each command).
 # Using PS0 would print the timestamp to the terminal; DEBUG is silent.
-# functrace is off by default, so DEBUG does not fire inside __traq_hook.
 __traq_preexec() {
     [[ -n "${COMP_LINE:-}" ]] && return
     [[ "$BASH_COMMAND" == "__traq_hook" ]] && return
@@ -33,10 +37,30 @@ __traq_escape() {
 
 __traq_hook() {
     local exit_code=$?
-    # Skip if no DEBUG preexec fired (e.g., first prompt of a new shell).
-    # Without this, history 1 returns stale entries from ~/.bash_history.
-    [[ -z "${__traq_start:-}" ]] && return
+
+    # Read the current history entry and its number.
+    local hist_line hist_num cmd
+    hist_line=$(HISTTIMEFORMAT= builtin history 1 2>/dev/null)
+    hist_num=$(printf '%s' "$hist_line" | awk '{print $1}')
+    cmd=$(printf '%s' "$hist_line" | sed 's/^ *[0-9]* *//')
+
+    # First call: establish baseline without logging. HISTFILE is loaded
+    # by now, so $hist_num reflects the last pre-existing history entry.
+    if [[ -z "$__traq_last_histnum" ]]; then
+        __traq_last_histnum="${hist_num:-0}"
+        unset __traq_start
+        return
+    fi
+
+    # Skip if the history number hasn't advanced.
+    if [[ -z "$hist_num" || "$hist_num" == "$__traq_last_histnum" ]]; then
+        unset __traq_start
+        return
+    fi
+    __traq_last_histnum="$hist_num"
+
     [[ -f "$__traq_marker" ]] || { unset __traq_start; return; }
+    [[ -z "$cmd" ]] && { unset __traq_start; return; }
 
     # Overflow check
     if [[ -f "$__traq_log" ]]; then
@@ -48,11 +72,6 @@ __traq_hook() {
             return
         fi
     fi
-
-    # Last command via HISTCMD-based lookup
-    local cmd
-    cmd=$(HISTTIMEFORMAT= builtin history 1 2>/dev/null | sed 's/^ *[0-9]* *//')
-    [[ -z "$cmd" ]] && { unset __traq_start; return; }
 
     local ts
     ts=$(date +%s)

--- a/internal/tracker/shellplugin/embed/traq.fish
+++ b/internal/tracker/shellplugin/embed/traq.fish
@@ -34,11 +34,12 @@ function __traq_postexec --on-event fish_postexec
         set duration_ms (math "($end - $__traq_start) / 1000000")
     end
 
+    # Format: session:window_idx/window_name:pane_idx/pane_cmd
+    # e.g. "main:2/logs:1/vim" or "0:0/fish:0/fish"
     set -l tmux_ctx "-"
     if set -q TMUX
-        set -l s (tmux display-message -p '#S' 2>/dev/null)
-        set -l w (tmux display-message -p '#I' 2>/dev/null)
-        test -n "$s"; and test -n "$w"; and set tmux_ctx "$s:$w"
+        set -l ctx (tmux display-message -p '#S:#I/#W:#P/#{pane_current_command}' 2>/dev/null)
+        test -n "$ctx"; and set tmux_ctx "$ctx"
     end
 
     set -l hostname (hostname -s 2>/dev/null; or echo "-")

--- a/internal/tracker/shellplugin/embed/traq.fish
+++ b/internal/tracker/shellplugin/embed/traq.fish
@@ -1,1 +1,59 @@
-# traq fish plugin — placeholder
+# Traq shell integration for fish.
+
+if set -q __TRAQ_LOADED
+    return
+end
+set -g __TRAQ_LOADED 1
+
+set -g __traq_dir (test -n "$XDG_DATA_HOME"; and echo "$XDG_DATA_HOME/traq/shell"; or echo "$HOME/.local/share/traq/shell")
+set -g __traq_marker "$__traq_dir/enabled"
+set -g __traq_log "$__traq_dir/history.log"
+set -g __traq_overflow "$__traq_dir/overflowed"
+set -g __traq_max_bytes 10485760
+
+function __traq_preexec --on-event fish_preexec
+    set -g __traq_cmd $argv[1]
+    set -g __traq_start (date +%s%N)
+end
+
+function __traq_postexec --on-event fish_postexec
+    set -l exit_code $status
+    test -f $__traq_marker; or return
+
+    if test -f $__traq_log
+        set -l size (wc -c < $__traq_log 2>/dev/null | string trim)
+        if test -n "$size"; and test $size -gt $__traq_max_bytes
+            touch $__traq_overflow
+            return
+        end
+    end
+
+    set -l duration_ms 0
+    if set -q __traq_start
+        set -l end (date +%s%N)
+        set duration_ms (math "($end - $__traq_start) / 1000000")
+    end
+
+    set -l tmux_ctx "-"
+    if set -q TMUX
+        set -l s (tmux display-message -p '#S' 2>/dev/null)
+        set -l w (tmux display-message -p '#I' 2>/dev/null)
+        test -n "$s"; and test -n "$w"; and set tmux_ctx "$s:$w"
+    end
+
+    set -l hostname (hostname -s 2>/dev/null; or echo "-")
+
+    # Escape: \ -> \\, then tab -> \t, newline -> \n
+    set -l cmd $__traq_cmd
+    set cmd (string replace -a '\\' '\\\\' -- $cmd)
+    set cmd (string replace -a \t '\\t' -- $cmd)
+    set cmd (string replace -a \n '\\n' -- $cmd)
+    if test (string length -- $cmd) -gt 4000
+        set cmd (string sub -l 4000 -- $cmd)"…"
+    end
+
+    mkdir -p $__traq_dir
+    printf '1\t%s\t%s\t%s\t%s\t%s\t%s\tfish\t%s\n' \
+        (date +%s) $exit_code $duration_ms $PWD $tmux_ctx $hostname $cmd \
+        >> $__traq_log
+end

--- a/internal/tracker/shellplugin/embed/traq.fish
+++ b/internal/tracker/shellplugin/embed/traq.fish
@@ -1,0 +1,1 @@
+# traq fish plugin — placeholder

--- a/internal/tracker/shellplugin/embed/traq.zsh
+++ b/internal/tracker/shellplugin/embed/traq.zsh
@@ -46,12 +46,13 @@ __traq_precmd() {
     end=$EPOCHREALTIME
     duration_ms=$(awk -v s="$__traq_start" -v e="$end" 'BEGIN{printf "%.0f", (e - s) * 1000}')
 
+    # Format: session:window_idx/window_name:pane_idx/pane_cmd
+    # e.g. "main:2/logs:1/vim" or "0:0/zsh:0/zsh"
     local tmux_ctx="-"
     if [[ -n "${TMUX:-}" ]]; then
-        local session window
-        session=$(tmux display-message -p '#S' 2>/dev/null)
-        window=$(tmux display-message -p '#I' 2>/dev/null)
-        [[ -n "$session" && -n "$window" ]] && tmux_ctx="${session}:${window}"
+        local ctx
+        ctx=$(tmux display-message -p '#S:#I/#W:#P/#{pane_current_command}' 2>/dev/null)
+        [[ -n "$ctx" ]] && tmux_ctx="$ctx"
     fi
 
     local hostname

--- a/internal/tracker/shellplugin/embed/traq.zsh
+++ b/internal/tracker/shellplugin/embed/traq.zsh
@@ -1,0 +1,1 @@
+# traq zsh plugin — placeholder

--- a/internal/tracker/shellplugin/embed/traq.zsh
+++ b/internal/tracker/shellplugin/embed/traq.zsh
@@ -1,1 +1,71 @@
-# traq zsh plugin — placeholder
+# Traq shell integration for zsh.
+
+[[ -n "${__TRAQ_LOADED:-}" ]] && return 0
+__TRAQ_LOADED=1
+
+__traq_dir="${XDG_DATA_HOME:-$HOME/.local/share}/traq/shell"
+__traq_marker="$__traq_dir/enabled"
+__traq_log="$__traq_dir/history.log"
+__traq_overflow="$__traq_dir/overflowed"
+__traq_max_bytes=10485760
+
+__traq_start=0
+
+__traq_preexec() {
+    __traq_cmd="$1"
+    __traq_start=$EPOCHREALTIME
+}
+
+__traq_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\n'/\\n}"
+    if (( ${#s} > 4000 )); then
+        s="${s:0:4000}…"
+    fi
+    print -rn -- "$s"
+}
+
+__traq_precmd() {
+    local exit_code=$?
+    [[ -z "${__traq_cmd:-}" ]] && return
+    [[ -f "$__traq_marker" ]] || { __traq_cmd=""; return; }
+
+    if [[ -f "$__traq_log" ]]; then
+        local size
+        size=$(wc -c < "$__traq_log" 2>/dev/null | tr -d ' ')
+        if [[ -n "$size" && "$size" -gt "$__traq_max_bytes" ]]; then
+            : > "$__traq_overflow"
+            __traq_cmd=""
+            return
+        fi
+    fi
+
+    local end duration_ms=0
+    end=$EPOCHREALTIME
+    duration_ms=$(awk -v s="$__traq_start" -v e="$end" 'BEGIN{printf "%.0f", (e - s) * 1000}')
+
+    local tmux_ctx="-"
+    if [[ -n "${TMUX:-}" ]]; then
+        local session window
+        session=$(tmux display-message -p '#S' 2>/dev/null)
+        window=$(tmux display-message -p '#I' 2>/dev/null)
+        [[ -n "$session" && -n "$window" ]] && tmux_ctx="${session}:${window}"
+    fi
+
+    local hostname
+    hostname=$(hostname -s 2>/dev/null || echo "-")
+
+    mkdir -p "$__traq_dir" 2>/dev/null
+    printf '1\t%s\t%s\t%s\t%s\t%s\t%s\tzsh\t%s\n' \
+        "$(date +%s)" "$exit_code" "$duration_ms" "$PWD" "$tmux_ctx" "$hostname" \
+        "$(__traq_escape "$__traq_cmd")" \
+        >> "$__traq_log"
+    __traq_cmd=""
+}
+
+autoload -Uz add-zsh-hook
+zmodload zsh/datetime 2>/dev/null
+add-zsh-hook preexec __traq_preexec
+add-zsh-hook precmd  __traq_precmd

--- a/internal/tracker/shellplugin/plugin_bash_test.go
+++ b/internal/tracker/shellplugin/plugin_bash_test.go
@@ -34,11 +34,16 @@ func TestBashPlugin_WritesLogLine(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Run bash interactively-ish: source the plugin, run one command, exit.
+	// Run bash interactively-ish: source the plugin, run two commands,
+	// invoking the hook manually between them. The first hook invocation
+	// establishes the baseline history number (by design — prevents logging
+	// stale pre-existing history); the second is what actually logs.
 	cmd := exec.Command("bash", "--noprofile", "--norc", "-c",
-		`set -o history; HISTFILE=/dev/null; source "$1"; echo hello; `+
-			`# PROMPT_COMMAND only fires at prompt; invoke hook manually:
-			__traq_hook`,
+		`set -o history; HISTFILE=/dev/null; source "$1"
+		echo first-cmd
+		__traq_hook  # baseline
+		echo hello
+		__traq_hook  # logs "echo hello"`,
 		"--", pluginPath)
 	cmd.Env = append(os.Environ(),
 		"HOME="+home,

--- a/internal/tracker/shellplugin/plugin_bash_test.go
+++ b/internal/tracker/shellplugin/plugin_bash_test.go
@@ -1,0 +1,62 @@
+//go:build !windows
+
+package shellplugin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBashPlugin_WritesLogLine(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not installed")
+	}
+
+	home := t.TempDir()
+	shellDir := filepath.Join(home, ".local", "share", "traq", "shell")
+	if err := os.MkdirAll(shellDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	// Marker present → plugin should log
+	if err := os.WriteFile(filepath.Join(shellDir, "enabled"), []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginPath := filepath.Join(home, "plugin.bash")
+	script, err := Script(Bash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, script, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run bash interactively-ish: source the plugin, run one command, exit.
+	cmd := exec.Command("bash", "--noprofile", "--norc", "-c",
+		`set -o history; HISTFILE=/dev/null; source "$1"; echo hello; `+
+			`# PROMPT_COMMAND only fires at prompt; invoke hook manually:
+			__traq_hook`,
+		"--", pluginPath)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash failed: %v\n%s", err, out)
+	}
+
+	logBytes, err := os.ReadFile(filepath.Join(shellDir, "history.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "\tbash\t") {
+		t.Errorf("log missing bash shell marker: %s", logBytes)
+	}
+	if !strings.Contains(string(logBytes), "echo hello") {
+		t.Errorf("log missing command: %s", logBytes)
+	}
+}

--- a/internal/tracker/shellplugin/plugin_fish_test.go
+++ b/internal/tracker/shellplugin/plugin_fish_test.go
@@ -1,0 +1,55 @@
+//go:build !windows
+
+package shellplugin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFishPlugin_WritesLogLine(t *testing.T) {
+	if _, err := exec.LookPath("fish"); err != nil {
+		t.Skip("fish not installed")
+	}
+
+	home := t.TempDir()
+	shellDir := filepath.Join(home, ".local", "share", "traq", "shell")
+	if err := os.MkdirAll(shellDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shellDir, "enabled"), []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginPath := filepath.Join(home, "plugin.fish")
+	script, err := Script(Fish)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, script, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("fish", "--no-config", "-c",
+		`source $argv[1]; emit fish_preexec "echo hello"; emit fish_postexec "echo hello"`,
+		pluginPath)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fish failed: %v\n%s", err, out)
+	}
+
+	logBytes, err := os.ReadFile(filepath.Join(shellDir, "history.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "\tfish\t") {
+		t.Errorf("log missing fish shell marker: %s", logBytes)
+	}
+}

--- a/internal/tracker/shellplugin/plugin_zsh_test.go
+++ b/internal/tracker/shellplugin/plugin_zsh_test.go
@@ -1,0 +1,58 @@
+//go:build !windows
+
+package shellplugin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestZshPlugin_WritesLogLine(t *testing.T) {
+	if _, err := exec.LookPath("zsh"); err != nil {
+		t.Skip("zsh not installed")
+	}
+
+	home := t.TempDir()
+	shellDir := filepath.Join(home, ".local", "share", "traq", "shell")
+	if err := os.MkdirAll(shellDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shellDir, "enabled"), []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginPath := filepath.Join(home, "plugin.zsh")
+	script, err := Script(Zsh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pluginPath, script, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("zsh", "--no-rcs", "-c",
+		`source "$1"; __traq_preexec "echo hello"; __traq_precmd`,
+		"--", pluginPath)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("zsh failed: %v\n%s", err, out)
+	}
+
+	logBytes, err := os.ReadFile(filepath.Join(shellDir, "history.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), "\tzsh\t") {
+		t.Errorf("log missing zsh shell marker: %s", logBytes)
+	}
+	if !strings.Contains(string(logBytes), "echo hello") {
+		t.Errorf("log missing command: %s", logBytes)
+	}
+}


### PR DESCRIPTION
## Summary

Re-opens #14 with all review feedback addressed. Stacked on #17 → #16 (the shell-plugin + project-assignment chain) because the AI lane shares the Settings UI plumbing and migration ordering those PRs introduce. If #16 and #17 land first, the diff here shrinks to the 14 AI-specific commits on top of master.

## Feature recap

- New **AI Coding** lane on the timeline that tracks Claude Code (JSONL session files) and opencode (SQLite DB) activity. Sessions appear as bars; individual user prompts surface as events in the dropdown.
- Storage migration 15 introduces `ai_sessions` + `ai_events` tables; migration 16 adds the optional `content` column for user-prompt previews.
- Two plugins (`aiplugin.ClaudePlugin`, `aiplugin.OpenCodePlugin`) poll external data sources on a timer. Both are read-only; opencode's DB is opened with `immutable=1` so the live process isn't disturbed.
- `AIService` derives per-session blocks (idle-gap split) and per-day prompt lists.
- Settings → Data Sources section with per-tool toggles, idle-gap slider, and the new privacy toggle (below).
- Post-close bugfix `9ab5789` for ongoing-session rendering is included (0-width bar fix).

## Addressed review feedback from #14

### Policy decision: opt-in prompt storage (option 4 from the brief)

The reviewer's **HIGH** concern: storing verbatim user-prompt text in `ai_events.content` contradicted the design doc's \"no transcript storage\" claim. Resolved via explicit user-opt-in rather than dropping the feature or documenting-and-shipping:

- New `AITrackingConfig.StorePromptContent` bool, **default false**.
- Plugins keep the `user_prompt` kind marker regardless of the toggle — the timeline still shows \"user prompted Claude at 14:32\" — but the `Content` field is dropped when off.
- Settings UI toggle in `DataSourcesSettings.tsx` with a two-sentence disclosure about the 0600 on-disk storage trade-off.
- Takes effect on next app restart. Intentionally not hot-reload: a privacy-sensitive toggle should have an explicit boundary where the user knows exactly when the behavior changed.
- Design doc updated: \"no transcript storage\" → \"no transcript storage **by default**\", with a rewritten Privacy section documenting what's stored in each mode.
- Tests cover both default-off (content empty) and opted-in (content populated) paths for Claude and opencode.

### Other review items (commit `62e826a`)

- **CRITICAL — migration 16 startup failure.** The top-level schema const already creates `ai_events` with the `content` column (since migration 16 exists), so fresh installs ran `CREATE TABLE` with content then hit migration 16's unguarded `ALTER TABLE ADD COLUMN content` → `duplicate column name` → startup fail. Upgrade DBs that went through `repairAIEventsTable` first had the same race. Fixed by guarding `applyMigration16` with `pragma_table_info` so it no-ops when the column exists; `repairAIEventsTable` also now logs failures via `log.Printf` instead of silently dropping errors.
- **HIGH — `AISessionDetail.FilePath` leaks absolute local path.** Changed JSON tag to `\"-\"` so the field stays on the Go struct for internal `stat` checks but is omitted from the Wails serialization. Updated generated `models.ts` to match. Grep confirmed no frontend code reads `AISessionDetail.filePath`.
- **MEDIUM — `AITracker.Poll` silently swallowed per-plugin errors.** Now logs via `log.Printf` with the plugin type so continuous failures (malformed JSONL, DB lock contention) are debuggable instead of invisible.
- **MEDIUM — missing `App.GetAIPromptsForDay` Wails binding.** Now exposed. Returns empty `Content` / `Preview` when the privacy toggle is off.
- **LOW — `osStat` global var.** Replaced with a per-instance `statFn` field on `AIService` + `SetStatFn` method. Default is `os.Stat`; production behavior unchanged.

## Known follow-up (out of scope for this PR)

`AITrackingConfig.Enabled` / `ClaudeEnabled` / `OpenCodeEnabled` are currently dead config — the Settings UI writes them to disk but the tracker ignores them (plugins always run). Flagged with an inline comment in `config.go`. Fix in a separate PR since it's a pre-existing bug in the original #14 work, orthogonal to the plaintext-storage policy question this PR resolves.

## Relationship to #11 / #12 / #13 / #14

- **#11 → PR #16** (shell plugin): foundation for the Settings UI section this PR extends. Stacked.
- **#12 → PR #15** (xgb window tracker): independent. Not in this stack.
- **#13 → PR #17** (project assignment): migration 14 predecessor to migration 15/16. Stacked.
- **#14 → this PR**: adds 14 AI-specific commits (dropped the `d49cfae`/`9e5a565` revert pair — they canceled to zero), plus two follow-up commits (policy-neutral fixes + opt-in toggle). Post-close bugfix `9ab5789` included.

Once #16 and #17 merge, GitHub will auto-retarget and the visible diff here shrinks to the AI work alone.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all green, including new Claude/opencode default-off + opted-in tests
- [x] `npx vitest run` — 147/147 passing
- [ ] Manual: Fresh install → verify no `duplicate column name` error at startup
- [ ] Manual: With Claude/opencode data on disk → AI lane renders, tooltips work, events dropdown lists user prompts with **no preview text** when toggle is off
- [ ] Manual: Flip `Store prompt text` toggle on, restart app → new prompts get previews in events list; existing prompts stay content-less until they're re-polled
- [ ] Manual: Flip toggle off, restart → subsequent prompts are captured without content; previously-captured content remains in DB (expected — toggle is forward-only for now, doesn't redact history)
- [ ] Manual: `GetAISession` via Wails → response has no `filePath` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)